### PR TITLE
Feat/2 manger dashboard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,10 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 export default [
+  // Global ignores
+  {
+    ignores: ["dist/**", "src-tauri/**", "node_modules/**"]
+  },
   // 1. 指定检查的文件类型
   {
     files: ["**/*.{js,mjs,cjs,vue}"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "echarts": "^6.0.0",
+        "pinia": "^3.0.4",
         "vue": "^3.5.13",
         "vue-router": "^4.6.4"
       },
@@ -1395,6 +1397,30 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.26",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
@@ -1516,6 +1542,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1588,6 +1623,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1646,6 +1696,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
     },
     "node_modules/entities": {
       "version": "7.0.0",
@@ -2048,6 +2108,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2106,6 +2172,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/isexe": {
@@ -2217,6 +2295,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2346,6 +2430,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2364,6 +2454,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
       }
     },
     "node_modules/postcss": {
@@ -2437,6 +2557,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.55.1",
@@ -2528,6 +2654,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2539,6 +2674,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {
@@ -2570,6 +2717,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2786,6 +2939,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "echarts": "^6.0.0",
+    "pinia": "^3.0.4",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,11 +33,16 @@ dependencies = [
 name = "ai-toolbox"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "chrono",
+ "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tokio",
 ]
 
 [[package]]
@@ -447,8 +464,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -489,6 +508,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -510,9 +539,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -523,7 +552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -803,6 +832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +916,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,12 +976,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -944,6 +1003,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1356,6 +1421,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,9 +1447,27 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1452,6 +1554,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1461,6 +1564,38 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1482,9 +1617,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1859,6 +1996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2131,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.17",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2292,6 +2457,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2865,22 +3074,30 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2890,6 +3107,34 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2915,6 +3160,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2991,6 +3278,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3343,6 +3653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3712,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,7 +3753,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3833,9 +4170,43 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4128,6 +4499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4175,6 +4552,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4560,6 +4943,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,6 +4996,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5065,6 +5468,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "futures-util",
  "reqwest",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,5 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
+futures-util = "0.3"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,9 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
+chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
 

--- a/src-tauri/src/commands/db.rs
+++ b/src-tauri/src/commands/db.rs
@@ -1,0 +1,23 @@
+use tauri::State;
+use crate::AppState;
+use crate::db::{self, TokenStat};
+
+/// Command to retrieve token usage statistics from the database.
+#[tauri::command]
+pub fn get_token_stats(state: State<'_, AppState>) -> Result<Vec<TokenStat>, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    db::get_aggregated_stats(&conn).map_err(|e| e.to_string())
+}
+
+/// Command to record token usage in the database.
+#[tauri::command]
+pub fn record_tokens(
+    state: State<'_, AppState>,
+    date: String,
+    prompt: i64,
+    completion: i64,
+    model: String,
+) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    db::record_tokens(&conn, &date, prompt, completion, &model).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod ollama;
+pub mod db;
+pub mod system;

--- a/src-tauri/src/commands/ollama.rs
+++ b/src-tauri/src/commands/ollama.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{State, Window, Emitter};
 use crate::AppState;
 use crate::ollama::{Model, RunningModel};
 
@@ -22,8 +22,14 @@ pub async fn delete_model(state: State<'_, AppState>, name: String) -> Result<()
 
 /// Command to pull a new model from Ollama.
 #[tauri::command]
-pub async fn pull_model(state: State<'_, AppState>, name: String) -> Result<(), String> {
-    state.ollama.pull_model(name).await.map_err(|e| e.to_string())
+pub async fn pull_model(
+    state: State<'_, AppState>, 
+    window: Window,
+    name: String
+) -> Result<(), String> {
+    state.ollama.pull_model(name, |progress| async {
+        let _ = window.emit("pull-progress", progress);
+    }).await.map_err(|e| e.to_string())
 }
 
 /// Command to start (load) a model into memory.

--- a/src-tauri/src/commands/ollama.rs
+++ b/src-tauri/src/commands/ollama.rs
@@ -1,0 +1,39 @@
+use tauri::State;
+use crate::AppState;
+use crate::ollama::{Model, RunningModel};
+
+/// Command to fetch all available models from Ollama.
+#[tauri::command]
+pub async fn get_models(state: State<'_, AppState>) -> Result<Vec<Model>, String> {
+    state.ollama.get_tags().await.map_err(|e| e.to_string())
+}
+
+/// Command to fetch currently running models and their resource usage.
+#[tauri::command]
+pub async fn get_running_models(state: State<'_, AppState>) -> Result<Vec<RunningModel>, String> {
+    state.ollama.get_running_models().await.map_err(|e| e.to_string())
+}
+
+/// Command to delete a model from Ollama.
+#[tauri::command]
+pub async fn delete_model(state: State<'_, AppState>, name: String) -> Result<(), String> {
+    state.ollama.delete_model(name).await.map_err(|e| e.to_string())
+}
+
+/// Command to pull a new model from Ollama.
+#[tauri::command]
+pub async fn pull_model(state: State<'_, AppState>, name: String) -> Result<(), String> {
+    state.ollama.pull_model(name).await.map_err(|e| e.to_string())
+}
+
+/// Command to start (load) a model into memory.
+#[tauri::command]
+pub async fn start_model(state: State<'_, AppState>, name: String) -> Result<(), String> {
+    state.ollama.start_model(name).await.map_err(|e| e.to_string())
+}
+
+/// Command to unload a model from memory to free VRAM.
+#[tauri::command]
+pub async fn unload_model(state: State<'_, AppState>, name: String) -> Result<(), String> {
+    state.ollama.unload_model(name).await.map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,0 +1,57 @@
+#[derive(serde::Serialize, Clone, Default)]
+pub struct GpuInfo {
+    pub name: String,
+    pub total_mb: u64,
+    pub used_mb: u64,
+}
+
+/// Command to get GPU info (Name, Total VRAM, Used VRAM).
+/// Uses PowerShell on Windows for broad support (AMD/Intel/NVIDIA).
+#[tauri::command]
+pub async fn get_gpu_info() -> Result<GpuInfo, String> {
+    let mut info = GpuInfo::default();
+
+    #[cfg(target_os = "windows")]
+    {
+        let ps_cmd = r#"
+            $total = Get-ItemProperty -Path 'HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\*' -ErrorAction SilentlyContinue | Where-Object { $_.'HardwareInformation.QwMemorySize' -gt 0 } | Sort-Object 'HardwareInformation.QwMemorySize' -Descending | Select-Object -First 1 DriverDesc, 'HardwareInformation.QwMemorySize'
+            $used = Get-Counter '\GPU Adapter Memory(*)\Dedicated Usage' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty CounterSamples | Sort-Object CookedValue -Descending | Select-Object -First 1 CookedValue
+            
+            if ($total) {
+                @{
+                    Name = $total.DriverDesc
+                    Total = $total.'HardwareInformation.QwMemorySize'
+                    Used = if ($used) { $used.CookedValue } else { 0 }
+                } | ConvertTo-Json
+            }
+        "#;
+        
+        let output = std::process::Command::new("powershell")
+            .args(["-NoProfile", "-Command", ps_cmd])
+            .output();
+
+        match output {
+            Ok(o) => {
+                if o.status.success() {
+                    let s = String::from_utf8_lossy(&o.stdout);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&s) {
+                        if let Some(name) = v["Name"].as_str() {
+                            info.name = name.to_string();
+                        }
+                        if let Some(total) = v["Total"].as_u64() {
+                            info.total_mb = total / 1024 / 1024;
+                        }
+                        if let Some(used) = v["Used"].as_f64() {
+                            info.used_mb = (used as u64) / 1024 / 1024;
+                        } else if let Some(used) = v["Used"].as_u64() {
+                            info.used_mb = used / 1024 / 1024;
+                        }
+                    }
+                }
+            }
+            Err(e) => println!("Failed to execute PowerShell: {}", e),
+        }
+    }
+
+    Ok(info)
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,71 @@
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+use anyhow::{Result, Context};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TokenStat {
+    pub date: String,
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+}
+
+/// Initialize the SQLite database.
+/// Creates the app data directory and the token_stats table if they don't exist.
+pub fn init_db(app_handle: &tauri::AppHandle) -> Result<Connection> {
+    let app_dir = app_handle.path().app_data_dir()
+        .context("Failed to get app data directory")?;
+    
+    if !app_dir.exists() {
+        std::fs::create_dir_all(&app_dir).context("Failed to create app data directory")?;
+    }
+
+    let db_path = app_dir.join("stats.db");
+    let conn = Connection::open(db_path).context("Failed to open database")?;
+    
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS token_stats (
+            id INTEGER PRIMARY KEY,
+            date TEXT NOT NULL,
+            prompt_tokens INTEGER NOT NULL,
+            completion_tokens INTEGER NOT NULL,
+            model_name TEXT NOT NULL
+        )",
+        [],
+    ).context("Failed to create table")?;
+    
+    Ok(conn)
+}
+
+/// Record token usage for a specific model on a specific date.
+pub fn record_tokens(conn: &Connection, date: &str, prompt: i64, completion: i64, model: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO token_stats (date, prompt_tokens, completion_tokens, model_name) VALUES (?1, ?2, ?3, ?4)",
+        params![date, prompt, completion, model],
+    ).context("Failed to insert token stats")?;
+    Ok(())
+}
+
+/// Retrieve aggregated token statistics grouped by date.
+pub fn get_aggregated_stats(conn: &Connection) -> Result<Vec<TokenStat>> {
+    let mut stmt = conn.prepare(
+        "SELECT date, SUM(prompt_tokens), SUM(completion_tokens) 
+         FROM token_stats 
+         GROUP BY date 
+         ORDER BY date ASC",
+    ).context("Failed to prepare query")?;
+    
+    let rows = stmt.query_map([], |row| {
+        Ok(TokenStat {
+            date: row.get(0)?,
+            prompt_tokens: row.get(1)?,
+            completion_tokens: row.get(2)?,
+        })
+    }).context("Failed to execute query")?;
+
+    let mut stats = Vec::new();
+    for row in rows {
+        stats.push(row.context("Failed to read row")?);
+    }
+    Ok(stats)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,44 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+mod db;
+mod ollama;
+mod commands;
+
+use ollama::OllamaClient;
+use std::sync::Mutex;
+use tauri::Manager;
+
+/// Application state shared across Tauri commands.
+pub struct AppState {
+    pub db: Mutex<rusqlite::Connection>,
+    pub ollama: OllamaClient,
 }
 
+/// The main entry point for the Tauri application.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .setup(|app| {
+            // Initialize database and setup state
+            let conn = db::init_db(app.handle())
+                .map_err(|e| e.to_string())?;
+            
+            app.manage(AppState {
+                db: Mutex::new(conn),
+                ollama: OllamaClient::new("http://localhost:11434".to_string()),
+            });
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            commands::ollama::get_models,
+            commands::ollama::get_running_models,
+            commands::ollama::delete_model,
+            commands::ollama::pull_model,
+            commands::ollama::start_model,
+            commands::ollama::unload_model,
+            commands::db::get_token_stats,
+            commands::db::record_tokens,
+            commands::system::get_gpu_info
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/ollama.rs
+++ b/src-tauri/src/ollama.rs
@@ -1,0 +1,113 @@
+use serde::{Deserialize, Serialize};
+use reqwest::Client;
+use anyhow::{Result, Context};
+
+/// Represents a model installed in Ollama.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Model {
+    pub name: String,
+    pub size: i64,
+    pub modified_at: String,
+}
+
+/// Response structure for the Ollama tags API.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TagsResponse {
+    pub models: Vec<Model>,
+}
+
+/// Represents a model currently running in memory.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RunningModel {
+    pub name: String,
+    pub size: i64,
+    pub size_vram: i64,
+}
+
+/// Response structure for the Ollama ps API.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProcessResponse {
+    pub models: Vec<RunningModel>,
+}
+
+/// Client for interacting with the Ollama API.
+pub struct OllamaClient {
+    client: Client,
+    base_url: String,
+}
+
+impl OllamaClient {
+    /// Create a new OllamaClient with the specified base URL.
+    pub fn new(base_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            base_url,
+        }
+    }
+
+    /// Fetch the list of installed models.
+    pub async fn get_tags(&self) -> Result<Vec<Model>> {
+        let url = format!("{}/api/tags", self.base_url);
+        let resp = self.client.get(url).send().await
+            .context("Failed to send get_tags request")?;
+        let tags: TagsResponse = resp.json().await
+            .context("Failed to parse tags response")?;
+        Ok(tags.models)
+    }
+
+    /// Fetch the list of currently running models.
+    pub async fn get_running_models(&self) -> Result<Vec<RunningModel>> {
+        let url = format!("{}/api/ps", self.base_url);
+        let resp = self.client.get(url).send().await
+            .context("Failed to send get_running_models request")?;
+        let ps: ProcessResponse = resp.json().await
+            .context("Failed to parse ps response")?;
+        Ok(ps.models)
+    }
+
+    /// Delete an installed model.
+    pub async fn delete_model(&self, name: String) -> Result<()> {
+        let url = format!("{}/api/delete", self.base_url);
+        self.client.delete(url)
+            .json(&serde_json::json!({ "name": name }))
+            .send().await
+            .context("Failed to send delete_model request")?;
+        Ok(())
+    }
+
+    /// Unload a model from memory (VRAM) by setting its keep_alive to 0.
+    pub async fn unload_model(&self, name: String) -> Result<()> {
+        let url = format!("{}/api/generate", self.base_url);
+        self.client.post(url)
+            .json(&serde_json::json!({
+                "model": name,
+                "keep_alive": 0
+            }))
+            .send().await
+            .context("Failed to send unload_model request")?;
+        Ok(())
+    }
+    
+    /// Pull (download) a new model from the Ollama library.
+    pub async fn pull_model(&self, name: String) -> Result<()> {
+        let url = format!("{}/api/pull", self.base_url);
+        self.client.post(url)
+            .json(&serde_json::json!({ "name": name, "stream": false }))
+            .send().await
+            .context("Failed to send pull_model request")?;
+        Ok(())
+    }
+
+    /// Start (preload) a model by sending an empty generate request.
+    pub async fn start_model(&self, name: String) -> Result<()> {
+        let url = format!("{}/api/generate", self.base_url);
+        self.client.post(url)
+            .json(&serde_json::json!({
+                "model": name,
+                "keep_alive": -1 // Keep loaded indefinitely
+            }))
+            .send().await
+            .context("Failed to send start_model request")?;
+        Ok(())
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
         "title": "ai-toolbox",
         "width": 1000,
         "height": 800,
+        "minHeight": 800,
+        "minWidth": 1000,
         "decorations": false
       }
     ],

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup>
 import TitleBar from "./components/TitleBar.vue";
 import AppSidebar from "./components/AppSidebar.vue";
+import ToastContainer from "./components/ToastContainer.vue";
 </script>
 
 <template>
@@ -12,26 +13,9 @@ import AppSidebar from "./components/AppSidebar.vue";
         <router-view />
       </main>
     </div>
+    <ToastContainer position="top-right" />
   </div>
 </template>
-
-<style>
-/* Global resets handled here or in main css */
-body {
-  margin: 0;
-  padding: 0;
-  overflow: hidden; /* Prevent body scroll, handle in content area */
-  background-color: #f6f6f6;
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: #2f2f2f;
-    color: #f6f6f6;
-  }
-}
-</style>
 
 <style scoped>
 .app-layout {
@@ -39,26 +23,27 @@ body {
   flex-direction: column;
   height: 100vh;
   width: 100vw;
+  background-color: var(--bg-app);
+  overflow: hidden; /* Critical: prevent body scroll */
 }
 
 .main-container {
   display: flex;
   flex: 1;
-  margin-top: 32px; /* Height of TitleBar */
+  /* TitleBar is usually around 30-32px. If it's fixed/absolute, we might need padding. 
+     If it's in the flex flow, we don't. Assuming TitleBar is in flex flow or fixed?
+     Let's check TitleBar style. It is fixed. So we need margin-top.
+  */
+  margin-top: 32px; 
   height: calc(100vh - 32px);
   overflow: hidden;
 }
 
 .content-area {
   flex: 1;
-  overflow-y: auto;
+  overflow-y: auto; /* Allow scrolling here */
   padding: 0;
-  background-color: var(--content-bg, #ffffff);
-}
-
-@media (prefers-color-scheme: dark) {
-  .content-area {
-    background-color: #1a1a1a;
-  }
+  background-color: var(--bg-app);
+  position: relative;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,10 @@
 import TitleBar from "./components/TitleBar.vue";
 import AppSidebar from "./components/AppSidebar.vue";
 import ToastContainer from "./components/ToastContainer.vue";
+import ConfirmDialog from "./components/common/ConfirmDialog.vue";
+import { useConfirm } from "./composables/useConfirm";
+
+const { state, onConfirm, onCancel } = useConfirm();
 </script>
 
 <template>
@@ -14,6 +18,15 @@ import ToastContainer from "./components/ToastContainer.vue";
       </main>
     </div>
     <ToastContainer position="top-right" />
+    <ConfirmDialog 
+      :show="state.show"
+      :title="state.title"
+      :message="state.message"
+      :confirm-text="state.confirmText"
+      :cancel-text="state.cancelText"
+      @confirm="onConfirm"
+      @cancel="onCancel"
+    />
   </div>
 </template>
 

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,171 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  /* Geek Light Theme Variables */
+  --bg-app: #ffffff;
+  --bg-sidebar: #f8f9fa;
+  --bg-panel: #ffffff;
+  --bg-hover: #e9ecef;
+  
+  --text-primary: #212529;
+  --text-secondary: #6c757d;
+  --text-code: #d63384;
+  
+  --border-color: #dee2e6;
+  
+  --primary-color: #0d6efd; /* Tech Blue */
+  --primary-hover: #0b5ed7;
+  --success-color: #198754; /* Tech Green */
+  --danger-color: #dc3545;
+  --warning-color: #ffc107;
+
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-mono: 'JetBrains Mono', 'Courier New', Courier, monospace;
+  
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+body {
+  background-color: var(--bg-app);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  margin: 0;
+  padding: 0;
+  overflow: hidden; /* Prevent body scroll, handled by layout */
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-sans); /* Keep headers clean, maybe mono for specific data headers */
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 0;
+}
+
+/* Utility Classes */
+.text-mono { font-family: var(--font-mono); }
+.text-muted { color: var(--text-secondary); }
+.text-primary { color: var(--primary-color); }
+.text-success { color: var(--success-color); }
+
+/* Buttons - Minimalist Geek Style */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: transparent;
+}
+
+.btn-primary {
+  background-color: var(--primary-color);
+  color: white;
+}
+.btn-primary:hover { background-color: var(--primary-hover); }
+
+.btn-success {
+  background-color: var(--success-color);
+  color: white;
+}
+.btn-success:hover {
+  background-color: #157347;
+}
+
+.btn-outline {
+  border-color: var(--border-color);
+  color: var(--text-primary);
+  background-color: white;
+}
+.btn-outline:hover {
+  background-color: var(--bg-hover);
+  border-color: #ced4da;
+}
+
+.btn-danger {
+  background-color: var(--danger-color);
+  color: white;
+  border: 1px solid var(--danger-color);
+}
+.btn-danger:hover {
+  background-color: #bb2d3b;
+  border-color: #bb2d3b;
+  color: white;
+}
+
+.btn-sm {
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Forms */
+input, select, textarea {
+  font-family: var(--font-sans);
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background-color: white;
+  color: var(--text-primary);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+input:focus, select:focus, textarea:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.1);
+}
+
+/* Cards / Panels */
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  /* box-shadow: var(--shadow-sm); removed for flatter geek look */
+}
+
+.panel-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-sidebar); /* Subtle contrast */
+  font-weight: 600;
+  font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-body {
+  padding: 16px;
+}
+
+/* Scrollbar Styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
+}

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="sidebar">
-    <div class="logo">
+    <div class="logo text-mono">
       AI Toolbox
     </div>
     <nav>
@@ -9,63 +9,132 @@
         class="nav-item"
         active-class="active"
       >
+        <span class="icon-box">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" /></svg>
+        </span>
         Home
+      </router-link>
+      <router-link
+        to="/models"
+        class="nav-item"
+        active-class="active"
+      >
+        <span class="icon-box">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><polyline points="3.27 6.96 12 12.01 20.73 6.96" /><line
+            x1="12"
+            y1="22.08"
+            x2="12"
+            y2="12"
+          /></svg>
+        </span>
+        Models
       </router-link>
       <router-link
         to="/settings"
         class="nav-item"
         active-class="active"
       >
+        <span class="icon-box">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><circle
+            cx="12"
+            cy="12"
+            r="3"
+          /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 5 9.4a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+        </span>
         Settings
       </router-link>
     </nav>
   </aside>
 </template>
 
-<script setup>
-// Sidebar navigation component
-</script>
-
 <style scoped>
 .sidebar {
-  width: 250px;
-  background-color: #2f3241;
-  color: white;
+  width: 240px;
+  background-color: var(--bg-sidebar);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   height: 100%;
+  flex-shrink: 0;
 }
 
 .logo {
-  padding: 20px;
-  font-size: 1.5em;
-  font-weight: bold;
-  text-align: center;
-  border-bottom: 1px solid #3e4255;
+  padding: 16px 20px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-color);
+  letter-spacing: -0.5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 nav {
+  padding: 16px 8px;
   display: flex;
   flex-direction: column;
-  padding: 10px;
+  gap: 4px;
 }
 
 .nav-item {
-  padding: 15px;
-  color: #a0a0a0;
+  padding: 8px 12px;
+  color: var(--text-secondary);
   text-decoration: none;
-  border-radius: 8px;
-  margin-bottom: 5px;
-  transition: background-color 0.2s, color 0.2s;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-box {
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .nav-item:hover {
-  background-color: #3e4255;
-  color: white;
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .nav-item.active {
-  background-color: #646cff;
+  background-color: var(--primary-color);
   color: white;
+  box-shadow: var(--shadow-sm);
 }
 </style>

--- a/src/components/ModelManager.vue
+++ b/src/components/ModelManager.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="model-manager">
+    <!-- Component for managing installed models -->
+    <ModelList 
+      :models="store.models" 
+      :running-models="store.runningModels"
+      :loading="store.loading"
+      :pulling="pulling"
+      :loading-states="loadingStates"
+      @pull="pullModel"
+      @start="startModel"
+      @delete="deleteModel"
+    />
+
+    <!-- Component for monitoring running processes and resources -->
+    <RunningProcesses 
+      :running-models="store.runningModels"
+      :gpu-info="store.gpuInfo"
+      :loading-states="loadingStates"
+      @stop="stopModel"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useModelStore } from '../store/models'
+import { useToast } from '../composables/useToast'
+import ModelList from './models/ModelList.vue'
+import RunningProcesses from './models/RunningProcesses.vue'
+
+/**
+ * ModelManager is the main container for model-related UI components.
+ * It orchestrates actions between the store and sub-components.
+ */
+const store = useModelStore()
+const { addToast } = useToast()
+
+const pulling = ref(false)
+const loadingStates = ref({}) // map of modelName -> 'starting' | 'stopping' | 'deleting'
+
+/**
+ * Pulls a new model from Ollama.
+ * @param {string} name 
+ */
+const pullModel = async (name) => {
+  pulling.value = true
+  addToast({ message: `Pulling model ${name}...`, type: 'info' })
+  try {
+    await store.pullModel(name)
+    addToast({ message: `Successfully pulled ${name}`, type: 'success' })
+  } catch (error) {
+    addToast({ message: 'Failed to pull model: ' + error, type: 'error' })
+  } finally {
+    pulling.value = false
+  }
+}
+
+/**
+ * Loads a model into memory.
+ * @param {string} name 
+ */
+const startModel = async (name) => {
+  if (loadingStates.value[name]) return
+  loadingStates.value[name] = 'starting'
+  try {
+    await store.startModel(name)
+    addToast({ message: `Started ${name}`, type: 'success' })
+  } catch (error) {
+    addToast({ message: 'Failed to start: ' + error, type: 'error' })
+  } finally {
+    loadingStates.value[name] = null
+  }
+}
+
+/**
+ * Unloads a model from memory to free VRAM.
+ * @param {string} name 
+ */
+const stopModel = async (name) => {
+  if (loadingStates.value[name]) return
+  loadingStates.value[name] = 'stopping'
+  try {
+    await store.unloadModel(name)
+    addToast({ message: `Stopped ${name}`, type: 'success' })
+  } catch (error) {
+    addToast({ message: 'Failed to stop: ' + error, type: 'error' })
+  } finally {
+    loadingStates.value[name] = null
+  }
+}
+
+/**
+ * Deletes a model from the local library.
+ * @param {string} name 
+ */
+const deleteModel = async (name) => {
+  if (!confirm(`Are you sure you want to delete ${name}?`)) return
+  if (loadingStates.value[name]) return
+  loadingStates.value[name] = 'deleting'
+  try {
+    await store.deleteModel(name)
+    addToast({ message: `Deleted ${name}`, type: 'success' })
+  } catch (error) {
+    addToast({ message: 'Failed to delete: ' + error, type: 'error' })
+  } finally {
+    loadingStates.value[name] = null
+  }
+}
+
+// Initial data fetch and periodic updates for running status
+onMounted(() => {
+  store.fetchModels()
+  store.fetchRunningModels()
+  store.fetchGpuInfo()
+  
+  // Refresh running models and GPU info every 5 seconds
+  const interval = setInterval(() => {
+    store.fetchRunningModels()
+    store.fetchGpuInfo()
+  }, 5000)
+  
+  // Cleanup on unmount (not strictly necessary for setInterval in this context but good practice)
+  return () => clearInterval(interval)
+})
+</script>
+
+<style scoped>
+.model-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+</style>

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -1,0 +1,70 @@
+<template>
+  <div
+    class="toast-container"
+    :class="position"
+  >
+    <TransitionGroup name="toast">
+      <ToastNotification
+        v-for="toast in toasts"
+        :key="toast.id"
+        :message="toast.message"
+        :type="toast.type"
+        @close="removeToast(toast.id)"
+      />
+    </TransitionGroup>
+  </div>
+</template>
+
+<script setup>
+import { useToast } from '../composables/useToast'
+import ToastNotification from './ToastNotification.vue'
+
+const props = defineProps({
+  position: {
+    type: String,
+    default: 'top-right',
+    validator: (value) => ['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(value)
+  }
+})
+
+const { toasts, removeToast } = useToast()
+</script>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  z-index: 9999;
+  padding: 20px;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Positioning - Adjusted to avoid Title Bar (approx 32px + padding) */
+.top-right { top: 40px; right: 0; }
+.top-left { top: 40px; left: 0; }
+.bottom-right { bottom: 0; right: 0; }
+.bottom-left { bottom: 0; left: 0; }
+
+/* Stacking order */
+.bottom-right, .bottom-left {
+  flex-direction: column-reverse;
+}
+
+/* Vue Transitions */
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.4s ease;
+}
+
+.toast-enter-from {
+  opacity: 0;
+  transform: translateX(100%);
+}
+
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(100%);
+}
+</style>

--- a/src/components/ToastNotification.vue
+++ b/src/components/ToastNotification.vue
@@ -1,0 +1,78 @@
+<template>
+  <div
+    :class="['toast', type]"
+    role="alert"
+  >
+    <div class="toast-icon">
+      <span v-if="type === 'success'">✅</span>
+      <span v-else-if="type === 'error'">❌</span>
+      <span v-else-if="type === 'warning'">⚠️</span>
+      <span v-else>ℹ️</span>
+    </div>
+    <div class="toast-content">
+      {{ message }}
+    </div>
+    <button
+      class="toast-close"
+      @click="$emit('close')"
+    >
+      ×
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  message: { type: String, required: true },
+  type: { type: String, default: 'info' } // success, error, warning, info
+})
+
+defineEmits(['close'])
+</script>
+
+<style scoped>
+.toast {
+  display: flex;
+  align-items: flex-start;
+  padding: 12px 16px;
+  background: white;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  min-width: 300px;
+  max-width: 400px;
+  border-left: 4px solid transparent;
+  pointer-events: auto;
+}
+
+.toast.success { border-left-color: var(--success-color); }
+.toast.error { border-left-color: var(--danger-color); }
+.toast.warning { border-left-color: var(--warning-color); }
+.toast.info { border-left-color: var(--primary-color); }
+
+.toast-icon {
+  margin-right: 12px;
+  font-size: 16px;
+}
+
+.toast-content {
+  flex: 1;
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0 0 8px;
+  margin-top: -2px;
+}
+
+.toast-close:hover {
+  color: var(--text-primary);
+}
+</style>

--- a/src/components/TokenChart.vue
+++ b/src/components/TokenChart.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="panel mt-4">
+    <div class="panel-header">
+      <span>Token Usage Trend</span>
+      <div class="legend">
+        <span class="dot primary" /> Input
+        <span class="dot success ml-2" /> Output
+      </div>
+    </div>
+    <div class="panel-body">
+      <div
+        ref="chartRef"
+        class="chart"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import * as echarts from 'echarts'
+import { invoke } from '@tauri-apps/api/core'
+
+/**
+ * TokenChart component visualizes input and output token usage over time using ECharts.
+ */
+const chartRef = ref(null)
+let chart = null
+
+/**
+ * Fetches token statistics from the backend and updates the chart.
+ */
+const updateChart = async () => {
+  try {
+    const stats = await invoke('get_token_stats')
+    const dates = stats.map(s => s.date)
+    const promptTokens = stats.map(s => s.prompt_tokens)
+    const completionTokens = stats.map(s => s.completion_tokens)
+
+    const option = {
+      backgroundColor: 'transparent',
+      tooltip: {
+        trigger: 'axis',
+        backgroundColor: 'rgba(255, 255, 255, 0.9)',
+        borderColor: '#dee2e6',
+        textStyle: { color: '#212529', fontFamily: 'Inter' },
+        axisPointer: { type: 'line', lineStyle: { color: '#adb5bd' } }
+      },
+      grid: {
+        left: '20px',
+        right: '20px',
+        bottom: '10px',
+        top: '10px',
+        containLabel: true
+      },
+      xAxis: {
+        type: 'category',
+        data: dates,
+        axisLine: { lineStyle: { color: '#dee2e6' } },
+        axisLabel: { color: '#6c757d', fontFamily: 'JetBrains Mono' },
+        axisTick: { show: false }
+      },
+      yAxis: {
+        type: 'value',
+        axisLine: { show: false },
+        splitLine: { lineStyle: { color: '#f1f3f5' } },
+        axisLabel: { color: '#6c757d', fontFamily: 'JetBrains Mono' }
+      },
+      series: [
+        {
+          name: 'Input',
+          type: 'line',
+          data: promptTokens,
+          smooth: true,
+          symbol: 'circle',
+          symbolSize: 6,
+          itemStyle: { color: '#0d6efd' },
+          lineStyle: { width: 2 }
+        },
+        {
+          name: 'Output',
+          type: 'line',
+          data: completionTokens,
+          smooth: true,
+          symbol: 'circle',
+          symbolSize: 6,
+          itemStyle: { color: '#198754' },
+          lineStyle: { width: 2 }
+        }
+      ]
+    }
+    chart.setOption(option)
+  } catch (error) {
+    console.error('Failed to update chart:', error)
+  }
+}
+
+onMounted(() => {
+  // Initialize chart instance
+  chart = echarts.init(chartRef.value)
+  updateChart()
+  
+  // Handle window resizing
+  window.addEventListener('resize', () => chart && chart.resize())
+})
+
+onUnmounted(() => {
+  // Clean up chart instance
+  if (chart) {
+    chart.dispose()
+  }
+})
+</script>
+
+<style scoped>
+.mt-4 { margin-top: 24px; }
+.chart { height: 300px; width: 100%; }
+
+.legend {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 4px;
+}
+.dot.primary { background-color: var(--primary-color); }
+.dot.success { background-color: var(--success-color); }
+.ml-2 { margin-left: 12px; }
+</style>

--- a/src/components/common/ConfirmDialog.vue
+++ b/src/components/common/ConfirmDialog.vue
@@ -1,0 +1,142 @@
+<template>
+  <Transition name="fade">
+    <div
+      v-if="show"
+      class="confirm-overlay"
+      @click.self="cancel"
+    >
+      <div class="confirm-dialog panel">
+        <div class="panel-header">
+          <span>{{ title }}</span>
+          <button
+            class="close-btn"
+            @click="cancel"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="panel-body">
+          <p class="confirm-message">
+            {{ message }}
+          </p>
+          <div class="confirm-actions">
+            <button
+              class="btn btn-outline"
+              @click="cancel"
+            >
+              {{ cancelText }}
+            </button>
+            <button
+              class="btn btn-danger"
+              @click="confirm"
+            >
+              {{ confirmText }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+/**
+ * Generic confirmation dialog component.
+ * Adheres to OCP by allowing customization of text and actions.
+ */
+defineProps({
+  show: Boolean,
+  title: {
+    type: String,
+    default: 'Confirm Action'
+  },
+  message: {
+    type: String,
+    default: 'Are you sure you want to proceed?'
+  },
+  confirmText: {
+    type: String,
+    default: 'Confirm'
+  },
+  cancelText: {
+    type: String,
+    default: 'Cancel'
+  }
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+const confirm = () => emit('confirm')
+const cancel = () => emit('cancel')
+</script>
+
+<style scoped>
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.confirm-dialog {
+  width: 100%;
+  max-width: 400px;
+  background-color: var(--bg-panel);
+  box-shadow: var(--shadow-md);
+  animation: slide-up 0.2s ease-out;
+}
+
+.confirm-message {
+  margin-bottom: 24px;
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.close-btn:hover {
+  color: var(--text-primary);
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/models/ModelItem.vue
+++ b/src/components/models/ModelItem.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="list-item">
+    <div class="item-info">
+      <div class="item-name text-mono">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="text-muted mr-1"
+          style="vertical-align: middle;"
+        ><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><polyline points="3.27 6.96 12 12.01 20.73 6.96" /><line
+          x1="12"
+          y1="22.08"
+          x2="12"
+          y2="12"
+        /></svg>
+        {{ model.name }}
+      </div>
+      <div class="item-meta text-muted">
+        {{ formatSize(model.size) }}
+      </div>
+    </div>
+    <div class="item-actions">
+      <!-- Start/Running Status Button -->
+      <button 
+        class="btn btn-sm btn-primary mr-2 d-flex gap-1" 
+        :class="{ 'btn-success': isRunning }" 
+        :disabled="isRunning || loadingState === 'starting'"
+        @click="$emit('start', model.name)"
+      >
+        <template v-if="loadingState === 'starting'">
+          ⏳ Starting...
+        </template>
+        <template v-else-if="isRunning">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><polyline points="20 6 9 17 4 12" /></svg>
+          Running
+        </template>
+        <template v-else>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><polygon points="5 3 19 12 5 21 5 3" /></svg>
+          Start
+        </template>
+      </button>
+      
+      <!-- Delete Button -->
+      <button 
+        class="btn btn-sm btn-danger d-flex gap-1" 
+        :disabled="!!loadingState"
+        @click="$emit('delete', model.name)"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+        {{ loadingState === 'deleting' ? '...' : 'Delete' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * ModelItem component displays a single model's information and action buttons.
+ */
+defineProps({
+  model: {
+    type: Object,
+    required: true
+  },
+  isRunning: {
+    type: Boolean,
+    default: false
+  },
+  loadingState: {
+    type: String,
+    default: null
+  }
+})
+
+defineEmits(['start', 'delete'])
+
+/**
+ * Formats byte size into human-readable string.
+ * @param {number} bytes 
+ */
+const formatSize = (bytes) => {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+</script>
+
+<style scoped>
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.list-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.list-item:first-child {
+  padding-top: 0;
+}
+
+.item-info {
+  flex: 1;
+  min-width: 0;
+  margin-right: 16px;
+}
+
+.item-name {
+  font-weight: 500;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.item-meta {
+  font-size: 12px;
+  margin-top: 2px;
+  margin-left: 20px;
+}
+
+.item-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.mr-2 { margin-right: 8px; }
+.mr-1 { margin-right: 4px; }
+.d-flex { display: flex; align-items: center; }
+.gap-1 { gap: 4px; }
+</style>

--- a/src/components/models/ModelList.vue
+++ b/src/components/models/ModelList.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="panel mb-4">
+    <div class="panel-header">
+      <span class="d-flex gap-2">📦 Installed Models</span>
+      <span
+        class="text-muted text-mono"
+        style="font-size: 12px"
+      >{{ models.length }} items</span>
+    </div>
+    <div class="panel-body">
+      <!-- Pull Model Input -->
+      <div class="d-flex gap-2 mb-3">
+        <input 
+          v-model="newModelName" 
+          placeholder="Pull model (e.g. llama3)" 
+          style="flex: 1"
+          @keyup.enter="handlePull"
+        >
+        <button
+          :disabled="pulling"
+          class="btn btn-primary d-flex gap-2"
+          @click="handlePull"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line
+            x1="12"
+            y1="15"
+            x2="12"
+            y2="3"
+          /></svg>
+          {{ pulling ? 'Pulling...' : 'Pull' }}
+        </button>
+      </div>
+      
+      <!-- Models List -->
+      <div
+        v-if="loading"
+        class="text-center p-3 text-muted"
+      >
+        <div class="spinner mb-2">
+          ⏳
+        </div>
+        Loading library...
+      </div>
+      <div
+        v-else
+        class="list-group"
+      >
+        <ModelItem 
+          v-for="model in models" 
+          :key="model.name" 
+          :model="model"
+          :is-running="isModelRunning(model.name)"
+          :loading-state="loadingStates[model.name]"
+          @start="$emit('start', $event)"
+          @delete="$emit('delete', $event)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import ModelItem from './ModelItem.vue'
+
+/**
+ * ModelList component manages the display of installed models and the pull interface.
+ */
+const props = defineProps({
+  models: {
+    type: Array,
+    required: true
+  },
+  runningModels: {
+    type: Array,
+    required: true
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  },
+  pulling: {
+    type: Boolean,
+    default: false
+  },
+  loadingStates: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const emit = defineEmits(['pull', 'start', 'delete'])
+
+const newModelName = ref('')
+
+/**
+ * Handles the pull model action.
+ */
+const handlePull = () => {
+  if (!newModelName.value) return
+  emit('pull', newModelName.value)
+  newModelName.value = ''
+}
+
+/**
+ * Checks if a model is currently running.
+ * @param {string} name 
+ */
+const isModelRunning = (name) => {
+  return props.runningModels.some(m => m.name === name)
+}
+</script>
+
+<style scoped>
+.mb-3 { margin-bottom: 16px; }
+.mb-4 { margin-bottom: 24px; }
+.gap-2 { gap: 8px; }
+.d-flex { display: flex; align-items: center; }
+.text-center { text-align: center; }
+.p-3 { padding: 16px; }
+.list-group { display: flex; flex-direction: column; }
+</style>

--- a/src/components/models/ModelList.vue
+++ b/src/components/models/ModelList.vue
@@ -40,6 +40,23 @@
           {{ pulling ? 'Pulling...' : 'Pull' }}
         </button>
       </div>
+
+      <!-- Pull Progress Bar -->
+      <div
+        v-if="pulling"
+        class="pull-progress-container mb-3"
+      >
+        <div class="progress-info mb-1">
+          <span class="status">{{ pullProgress.status }}</span>
+          <span class="percentage text-mono">{{ pullProgress.percentage }}%</span>
+        </div>
+        <div class="progress-bar-bg">
+          <div 
+            class="progress-bar-fill" 
+            :style="{ width: pullProgress.percentage + '%' }"
+          />
+        </div>
+      </div>
       
       <!-- Models List -->
       <div
@@ -93,6 +110,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  pullProgress: {
+    type: Object,
+    default: () => ({ status: '', completed: 0, total: 0, percentage: 0 })
+  },
   loadingStates: {
     type: Object,
     default: () => ({})
@@ -129,4 +150,33 @@ const isModelRunning = (name) => {
 .text-center { text-align: center; }
 .p-3 { padding: 16px; }
 .list-group { display: flex; flex-direction: column; }
+
+.pull-progress-container {
+  padding: 12px;
+  background-color: var(--bg-sidebar);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+}
+
+.progress-info {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.progress-bar-bg {
+  height: 6px;
+  background-color: var(--border-color);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background-color: var(--primary-color);
+  transition: width 0.3s ease;
+}
+
+.mb-1 { margin-bottom: 4px; }
 </style>

--- a/src/components/models/RunningProcesses.vue
+++ b/src/components/models/RunningProcesses.vue
@@ -1,0 +1,224 @@
+<template>
+  <div class="panel">
+    <div
+      class="panel-header"
+      style="justify-content: space-between; align-items: center;"
+    >
+      <span class="d-flex gap-2">🚀 Running Processes</span>
+      
+      <!-- GPU Info Section -->
+      <div
+        v-if="gpuInfo.name || gpuInfo.total > 0"
+        class="d-flex flex-column align-items-end"
+      >
+        <div
+          v-if="gpuInfo.name"
+          class="text-muted text-mono mb-1"
+          style="font-size: 10px;"
+        >
+          {{ gpuInfo.name }}
+        </div>
+        <div
+          v-if="gpuInfo.total > 0"
+          class="d-flex align-items-center gap-2 text-muted"
+          style="font-size: 11px;"
+        >
+          <div
+            class="vram-progress-track"
+            style="width: 80px;"
+          >
+            <div 
+              class="vram-progress-fill" 
+              :style="{ 
+                width: (gpuInfo.used / gpuInfo.total * 100) + '%', 
+                backgroundColor: (gpuInfo.used / gpuInfo.total) > 0.8 ? 'var(--danger-color)' : 'var(--primary-color)' 
+              }"
+            />
+          </div>
+          <span>{{ (gpuInfo.used / gpuInfo.total * 100).toFixed(0) }}%</span>
+        </div>
+      </div>
+      <span
+        v-else
+        class="text-success text-mono"
+        style="font-size: 12px"
+      >Active</span>
+    </div>
+    
+    <div class="panel-body">
+      <!-- Empty State -->
+      <div
+        v-if="runningModels.length === 0"
+        class="text-center p-4 text-muted"
+      >
+        <div style="font-size: 24px; margin-bottom: 8px;">
+          😴
+        </div>
+        No models currently running.
+      </div>
+      
+      <!-- Running Models List -->
+      <div
+        v-else
+        class="list-group"
+      >
+        <div
+          v-for="model in runningModels"
+          :key="model.name"
+          class="list-item"
+        >
+          <div class="item-info">
+            <div class="item-name text-mono text-primary d-flex gap-2">
+              <span class="status-dot" />
+              {{ model.name }}
+            </div>
+            <div class="item-meta text-muted">
+              VRAM: {{ formatSize(model.size_vram) }}
+            </div>
+          </div>
+          <div class="item-actions">
+            <button 
+              class="btn btn-sm btn-danger d-flex gap-1" 
+              :disabled="loadingStates[model.name] === 'stopping'"
+              @click="$emit('stop', model.name)"
+            >
+              <template v-if="loadingStates[model.name] === 'stopping'">
+                ⏳ Stopping...
+              </template>
+              <template v-else>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                ><rect
+                  x="3"
+                  y="3"
+                  width="18"
+                  height="18"
+                  rx="2"
+                  ry="2"
+                /></svg>
+                Stop
+              </template>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * RunningProcesses component shows currently active models and system resource usage.
+ */
+defineProps({
+  runningModels: {
+    type: Array,
+    required: true
+  },
+  gpuInfo: {
+    type: Object,
+    required: true
+  },
+  loadingStates: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+defineEmits(['stop'])
+
+/**
+ * Formats byte size into human-readable string.
+ */
+const formatSize = (bytes) => {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+</script>
+
+<style scoped>
+.d-flex { display: flex; align-items: center; }
+.flex-column { flex-direction: column; }
+.align-items-end { align-items: flex-end; }
+.gap-2 { gap: 8px; }
+.gap-1 { gap: 4px; }
+.mb-1 { margin-bottom: 4px; }
+.text-center { text-align: center; }
+.p-4 { padding: 32px; }
+
+.list-group { display: flex; flex-direction: column; }
+
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.list-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.item-info {
+  flex: 1;
+  min-width: 0;
+  margin-right: 16px;
+}
+
+.item-name {
+  font-weight: 500;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.item-meta {
+  font-size: 12px;
+  margin-top: 2px;
+  margin-left: 20px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  background-color: var(--success-color);
+  border-radius: 50%;
+  display: inline-block;
+  box-shadow: 0 0 0 2px rgba(25, 135, 84, 0.2);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(25, 135, 84, 0.4); }
+  70% { box-shadow: 0 0 0 6px rgba(25, 135, 84, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(25, 135, 84, 0); }
+}
+
+.vram-progress-track {
+  height: 6px;
+  background-color: var(--bg-hover);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.vram-progress-fill {
+  height: 100%;
+  background-color: var(--primary-color);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+</style>

--- a/src/composables/useConfirm.js
+++ b/src/composables/useConfirm.js
@@ -1,0 +1,45 @@
+import { ref, reactive } from 'vue'
+
+const state = reactive({
+  show: false,
+  title: '',
+  message: '',
+  confirmText: 'Confirm',
+  cancelText: 'Cancel',
+  resolve: null
+})
+
+/**
+ * Composable for managing a global confirmation dialog.
+ * Returns a promise that resolves to true on confirm and false on cancel.
+ */
+export function useConfirm() {
+  const confirm = (options = {}) => {
+    state.title = options.title || 'Confirm Action'
+    state.message = options.message || 'Are you sure?'
+    state.confirmText = options.confirmText || 'Confirm'
+    state.cancelText = options.cancelText || 'Cancel'
+    state.show = true
+
+    return new Promise((resolve) => {
+      state.resolve = resolve
+    })
+  }
+
+  const onConfirm = () => {
+    state.show = false
+    if (state.resolve) state.resolve(true)
+  }
+
+  const onCancel = () => {
+    state.show = false
+    if (state.resolve) state.resolve(false)
+  }
+
+  return {
+    state,
+    confirm,
+    onConfirm,
+    onCancel
+  }
+}

--- a/src/composables/useToast.js
+++ b/src/composables/useToast.js
@@ -1,0 +1,46 @@
+import { ref } from 'vue'
+
+const toasts = ref([])
+let idCounter = 0
+
+export function useToast() {
+  /**
+   * Add a new toast notification.
+   * @param {Object} options
+   * @param {string} options.message - The message to display.
+   * @param {'success'|'info'|'warning'|'error'} [options.type='info'] - The type of notification.
+   * @param {number} [options.duration=3000] - Duration in ms. 0 for persistent.
+   */
+  const addToast = ({ message, type = 'info', duration = 3000 }) => {
+    const id = idCounter++
+    const toast = {
+      id,
+      message,
+      type,
+      duration
+    }
+    
+    // Add to the beginning (top) or end? Usually stacks stack up or down.
+    // Let's add to the array. The container determines rendering order.
+    toasts.value.push(toast)
+
+    if (duration > 0) {
+      setTimeout(() => {
+        removeToast(id)
+      }, duration)
+    }
+  }
+
+  const removeToast = (id) => {
+    const index = toasts.value.findIndex(t => t.id === id)
+    if (index !== -1) {
+      toasts.value.splice(index, 1)
+    }
+  }
+
+  return {
+    toasts,
+    addToast,
+    removeToast
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,12 @@
-import { createApp } from "vue";
-import App from "./App.vue";
-import router from "./router";
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import router from './router'
+import './assets/main.css'
 
-createApp(App).use(router).mount("#app");
+const app = createApp(App)
+const pinia = createPinia()
+
+app.use(pinia)
+app.use(router)
+app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,11 @@ const routes = [
     component: () => import('../views/HomeView.vue')
   },
   {
+    path: '/models',
+    name: 'Models',
+    component: () => import('../views/ModelsView.vue')
+  },
+  {
     path: '/settings',
     name: 'Settings',
     component: () => import('../views/SettingsView.vue')

--- a/src/store/models.js
+++ b/src/store/models.js
@@ -1,0 +1,124 @@
+import { defineStore } from 'pinia'
+import { invoke } from '@tauri-apps/api/core'
+
+/**
+ * Pinia store for managing Ollama models, running processes, and system resource info.
+ */
+export const useModelStore = defineStore('models', {
+  state: () => ({
+    models: [],           // List of installed models
+    runningModels: [],    // List of models currently in VRAM
+    loading: false,       // Loading state for model list
+    selectedModel: '',    // Currently selected model for chat
+    gpuInfo: { name: '', total: 0, used: 0 }, // GPU resource usage
+  }),
+
+  actions: {
+    /**
+     * Fetches the list of all installed models from the Ollama server.
+     */
+    async fetchModels() {
+      this.loading = true
+      try {
+        this.models = await invoke('get_models')
+      } catch (error) {
+        console.error('Failed to fetch models:', error)
+      } finally {
+        this.loading = false
+      }
+    },
+    
+    /**
+     * Fetches GPU information and VRAM usage from the system.
+     */
+    async fetchGpuInfo() {
+      try {
+        const info = await invoke('get_gpu_info')
+        // Backend returns MB, convert to Bytes for consistent formatting in frontend
+        this.gpuInfo = {
+          name: info.name,
+          total: info.total_mb * 1024 * 1024,
+          used: info.used_mb * 1024 * 1024
+        }
+      } catch (error) {
+        console.warn('Failed to fetch GPU info:', error)
+      }
+    },
+
+    /**
+     * Fetches the list of models currently loaded in memory.
+     */
+    async fetchRunningModels() {
+      try {
+        this.runningModels = await invoke('get_running_models')
+      } catch (error) {
+        console.error('Failed to fetch running models:', error)
+      }
+    },
+
+    /**
+     * Pulls (downloads) a new model by name.
+     * @param {string} name - The name of the model to pull (e.g., "llama3").
+     */
+    async pullModel(name) {
+      try {
+        await invoke('pull_model', { name })
+        await this.fetchModels()
+      } catch (error) {
+        console.error('Failed to pull model:', error)
+        throw error
+      }
+    },
+
+    /**
+     * Deletes an installed model.
+     * @param {string} name - The name of the model to delete.
+     */
+    async deleteModel(name) {
+      try {
+        await invoke('delete_model', { name })
+        await this.fetchModels()
+      } catch (error) {
+        console.error('Failed to delete model:', error)
+        throw error
+      }
+    },
+
+    /**
+     * Starts (preloads) a model into VRAM.
+     * @param {string} name - The name of the model to start.
+     */
+    async startModel(name) {
+      try {
+        await invoke('start_model', { name })
+        await this.fetchRunningModels()
+      } catch (error) {
+        console.error('Failed to start model:', error)
+        throw error
+      }
+    },
+
+    /**
+     * Unloads a model from memory to free up VRAM.
+     * @param {string} name - The name of the model to unload.
+     */
+    async unloadModel(name) {
+      try {
+        await invoke('unload_model', { name })
+        await this.fetchRunningModels()
+      } catch (error) {
+        console.error('Failed to unload model:', error)
+        throw error
+      }
+    },
+
+    /**
+     * Selects a model to be used for chat sessions.
+     * @param {string} name - The name of the model to select.
+     */
+    selectModel(name) {
+      this.selectedModel = name
+      localStorage.setItem('selectedModel', name)
+    }
+  }
+})

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,16 +1,467 @@
 <template>
-  <div class="home-view">
-    <h1>Home</h1>
-    <p>Welcome to the AI Toolbox.</p>
+  <div class="chat-container">
+    <div
+      ref="messagesRef"
+      class="messages"
+    >
+      <div
+        v-for="(msg, index) in messages"
+        :key="index"
+        :class="['message-wrapper', msg.role]"
+      >
+        <div class="message-row">
+          <div
+            v-if="msg.role === 'assistant'"
+            class="avatar"
+          >
+            🤖
+          </div>
+          
+          <div class="content-column">
+            <div class="message-meta">
+              <span
+                class="role-badge text-mono"
+                :class="msg.role"
+              >{{ msg.role === 'user' ? 'YOU' : 'AI' }}</span>
+            </div>
+            <div class="message-bubble panel">
+              <div class="panel-body">
+                {{ msg.content }}
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="msg.role === 'user'"
+            class="avatar"
+          >
+            👤
+          </div>
+        </div>
+      </div>
+      
+      <div
+        v-if="loading"
+        class="message-wrapper assistant"
+      >
+        <div class="message-row">
+          <div class="avatar">
+            🤖
+          </div>
+          <div class="content-column">
+            <div class="message-meta">
+              <span class="role-badge assistant text-mono">AI</span>
+            </div>
+            <div class="message-bubble panel">
+              <div class="panel-body text-muted">
+                <span class="typing-indicator">Thinking... 💭</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="input-area panel">
+      <div
+        class="panel-header"
+        style="background: transparent; padding: 8px 12px; border-bottom: none;"
+      >
+        <select
+          v-model="store.selectedModel"
+          class="model-select"
+          @change="store.selectModel($event.target.value)"
+        >
+          <option
+            disabled
+            value=""
+          >
+            Select Model
+          </option>
+          <option
+            v-for="model in store.models"
+            :key="model.name"
+            :value="model.name"
+          >
+            {{ model.name }}
+          </option>
+        </select>
+      </div>
+      <div
+        class="panel-body"
+        style="padding: 0 12px 12px 12px;"
+      >
+        <div class="input-wrapper">
+          <textarea 
+            v-model="input" 
+            placeholder="Type your message here..." 
+            :disabled="loading"
+            rows="3"
+            @keydown.enter.prevent="sendMessage"
+          />
+          <button
+            :disabled="loading || !store.selectedModel"
+            class="btn btn-primary send-btn"
+            @click="sendMessage"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ><line
+              x1="22"
+              y1="2"
+              x2="11"
+              y2="13"
+            /><polygon points="22 2 15 22 11 13 2 9 22 2" /></svg>
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-// Home view logic
+import { ref, onMounted, nextTick } from 'vue'
+import { useModelStore } from '../store/models'
+import { invoke } from '@tauri-apps/api/core'
+
+const store = useModelStore()
+const input = ref('')
+const messages = ref([])
+const loading = ref(false)
+const messagesRef = ref(null)
+
+const sendMessage = async () => {
+  if (!input.value.trim() || !store.selectedModel) return
+
+  const userMsg = input.value
+  messages.value.push({ role: 'user', content: userMsg })
+  input.value = ''
+  loading.value = true
+  
+  await scrollToBottom()
+
+  try {
+    const response = await fetch('http://localhost:11434/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: store.selectedModel,
+        prompt: userMsg,
+        stream: false
+      })
+    })
+    
+    const data = await response.json()
+    messages.value.push({ role: 'assistant', content: data.response })
+    
+    const today = new Date().toISOString().split('T')[0]
+    await invoke('record_tokens', {
+      date: today,
+      prompt: data.prompt_eval_count || 0,
+      completion: data.eval_count || 0,
+      model: store.selectedModel
+    })
+    
+  } catch (error) {
+    messages.value.push({ role: 'assistant', content: 'Error: ' + error })
+  } finally {
+    loading.value = false
+    await scrollToBottom()
+  }
+}
+
+const scrollToBottom = async () => {
+  await nextTick()
+  if (messagesRef.value) {
+    messagesRef.value.scrollTop = messagesRef.value.scrollHeight
+  }
+}
+
+onMounted(async () => {
+  await store.fetchModels()
+  if (!store.selectedModel && store.models.length > 0) {
+    store.selectModel(store.models[0].name)
+  }
+})
 </script>
 
 <style scoped>
-.home-view {
-  padding: 20px;
+
+.chat-container {
+
+  display: flex;
+
+  flex-direction: column;
+
+  height: 100%;
+
+  padding: 24px;
+
+  max-width: 900px;
+
+  margin: 0 auto;
+
 }
+
+
+
+.messages {
+
+  flex: 1;
+
+  overflow-y: auto;
+
+  margin-bottom: 24px;
+
+  padding-right: 8px;
+
+}
+
+
+
+.message-wrapper {
+
+  margin-bottom: 24px;
+
+}
+
+
+
+.message-row {
+
+  display: flex;
+
+  gap: 12px;
+
+  max-width: 80%;
+
+}
+
+
+
+.message-wrapper.user .message-row {
+
+  flex-direction: row;
+
+  margin-left: auto;
+
+  justify-content: flex-end;
+
+}
+
+
+
+.avatar {
+
+  width: 36px;
+
+  height: 36px;
+
+  background-color: white;
+
+  border: 1px solid var(--border-color);
+
+  border-radius: 50%;
+
+  display: flex;
+
+  align-items: center;
+
+  justify-content: center;
+
+  font-size: 20px;
+
+  flex-shrink: 0;
+
+  box-shadow: var(--shadow-sm);
+
+}
+
+
+
+.content-column {
+
+  display: flex;
+
+  flex-direction: column;
+
+}
+
+
+
+.message-wrapper.user .content-column {
+
+  align-items: flex-end;
+
+}
+
+
+
+.message-meta {
+
+  margin-bottom: 4px;
+
+}
+
+
+
+.role-badge {
+
+  font-size: 10px;
+
+  font-weight: 700;
+
+  color: var(--text-secondary);
+
+  text-transform: uppercase;
+
+}
+
+
+
+.message-bubble {
+
+  background: white;
+
+  box-shadow: var(--shadow-sm);
+
+  border-radius: var(--radius-md);
+
+  position: relative;
+
+}
+
+
+
+/* Bubbles have little tails? Maybe later. For now just clean rounded boxes. */
+
+.message-wrapper.assistant .message-bubble {
+
+  border-top-left-radius: 0;
+
+}
+
+
+
+.message-wrapper.user .message-bubble {
+
+  background: #f1f8ff; /* Very light blue for user */
+
+  border-color: #cce5ff;
+
+  border-top-right-radius: 0;
+
+}
+
+
+
+.input-area {
+
+  flex-shrink: 0;
+
+  border-color: var(--primary-color); /* Highlight input area */
+
+  box-shadow: var(--shadow-md);
+
+}
+
+
+
+.input-wrapper {
+
+  position: relative;
+
+  display: flex;
+
+  align-items: flex-end;
+
+}
+
+
+
+textarea {
+
+  width: 100%;
+
+  border: none; /* Managed by panel */
+
+  background: transparent;
+
+  resize: none;
+
+  font-family: var(--font-sans);
+
+  padding-right: 40px; /* Space for send button */
+
+}
+
+
+
+textarea:focus {
+
+  box-shadow: none;
+
+}
+
+
+
+.send-btn {
+
+  position: absolute;
+
+  bottom: 0;
+
+  right: 0;
+
+  padding: 8px;
+
+  background: transparent;
+
+  color: var(--primary-color);
+
+  border: none;
+
+}
+
+
+
+.send-btn:hover {
+
+  background: var(--bg-hover);
+
+  color: var(--primary-hover);
+
+}
+
+
+
+.send-btn:disabled {
+
+  color: var(--text-secondary);
+
+}
+
+
+
+.model-select {
+
+  border: none;
+
+  background: transparent;
+
+  font-weight: 600;
+
+  color: var(--text-primary);
+
+  padding-left: 0;
+
+}
+
 </style>

--- a/src/views/ModelsView.vue
+++ b/src/views/ModelsView.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="models-view">
+    <div class="header-section mb-4">
+      <h1>Models</h1>
+      <p class="text-muted">
+        Manage your local LLMs and monitor system resources.
+      </p>
+    </div>
+    
+    <ModelManager />
+    <TokenChart />
+  </div>
+</template>
+
+<script setup>
+import ModelManager from '../components/ModelManager.vue'
+import TokenChart from '../components/TokenChart.vue'
+</script>
+
+<style scoped>
+.models-view {
+  padding: 32px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.mb-4 { margin-bottom: 24px; }
+</style>


### PR DESCRIPTION
## Summary (摘要)
Closes #2

本 PR 实现了 Ollama 模型的完整管理功能，并引入了数据可视化大屏。
- 引入 `rusqlite` 实现本地 SQLite 存储，记录 Token 使用历史。
- 封装 Ollama API (List, Pull, Delete)。
- 前端实现了一些通用组件，比如通知提示框，确认对话框等
- 前端`model`页面新增 "模型管理" 和 "数据仪表盘" ，添加了拉取模型时的进度条显示。

## Changes (变动细节)
- **Infrastructure**:
    - 添加 `rusqlite`, `serde`, `reqwest`, `pinia`, `echarts` , `futures-util `依赖。
- **Backend (Rust)**:
    - `db.rs`: 实现了 `token_stats` 表的自动初始化和插入/查询逻辑。
    - `ollama.rs`: 封装了与本地 Ollama 服务的 HTTP 通信。
    - `system.rs`: 实现了从系统获得当前显卡的显存占用率
- **Frontend (Vue)**:
    - `TokenChart.vue`: 使用 ECharts 展示每日 Token 趋势。
    - `ModelManager.vue`: 实现了模型的下载进度条和删除确认弹窗。

## Screenshots (截图 - 必须项)
<img width="1002" height="915" alt="image" src="https://github.com/user-attachments/assets/85936aa5-81ab-4604-afbc-0ced33eef834" />
<img width="1002" height="915" alt="image" src="https://github.com/user-attachments/assets/060586d5-b624-4352-b237-5241f0a7fffa" />


## Checklist (自测清单)
- [x] 在没有安装 Ollama 的环境下运行，应用不会崩溃（有错误提示）。
- [x] 能够正常下载大模型，进度条显示正常。
- [x] 数据库文件 (`stats.db`) 能在 `AppLocalData` 目录下自动生成。
- [x] `npm run lint` 和 `cargo test` 本地通过。