### PR TITLE
Feat/7 add setting page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,34 @@
         "@tauri-apps/plugin-opener": "^2",
         "echarts": "^6.0.0",
         "pinia": "^3.0.4",
+        "pinia-plugin-persistedstate": "^4.7.1",
         "vue": "^3.5.13",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.18",
         "@tauri-apps/cli": "^2",
         "@vitejs/plugin-vue": "^5.2.1",
+        "autoprefixer": "^10.4.23",
         "eslint": "^9.39.2",
         "eslint-plugin-vue": "^10.7.0",
         "globals": "^17.0.0",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.18",
         "vite": "^6.0.3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -721,11 +739,54 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.55.1",
@@ -1076,6 +1137,277 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
+      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
+      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-x64": "4.1.18",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
+      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
+      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
+      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
+      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
+      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
+      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
+      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
+      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
+      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.18.tgz",
+      "integrity": "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.18",
+        "@tailwindcss/oxide": "4.1.18",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.18"
+      }
     },
     "node_modules/@tauri-apps/api": {
       "version": "2.9.1",
@@ -1535,12 +1867,59 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.23",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+      "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001760",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.15.tgz",
+      "integrity": "sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
     },
     "node_modules/birpc": {
       "version": "2.9.0",
@@ -1569,6 +1948,41 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1578,6 +1992,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1697,6 +2132,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/echarts": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
@@ -1705,6 +2156,27 @@
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
+      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -1759,6 +2231,16 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2057,6 +2539,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2097,6 +2593,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2193,6 +2696,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2249,6 +2763,268 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -2331,6 +3107,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2477,6 +3260,31 @@
         }
       }
     },
+    "node_modules/pinia-plugin-persistedstate": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-4.7.1.tgz",
+      "integrity": "sha512-WHOqh2esDlR3eAaknPbqXrkkj0D24h8shrDPqysgCFR6ghqP/fpFfJmMPJp0gETHsvrh9YNNg6dQfo2OEtDnIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "@pinia/nuxt": ">=0.10.0",
+        "pinia": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "@pinia/nuxt": {
+          "optional": true
+        },
+        "pinia": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pinia/node_modules/@vue/devtools-api": {
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
@@ -2505,6 +3313,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2527,6 +3336,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -2701,6 +3517,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2735,6 +3572,37 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -16,15 +16,20 @@
     "@tauri-apps/plugin-opener": "^2",
     "echarts": "^6.0.0",
     "pinia": "^3.0.4",
+    "pinia-plugin-persistedstate": "^4.7.1",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.18",
     "@tauri-apps/cli": "^2",
     "@vitejs/plugin-vue": "^5.2.1",
+    "autoprefixer": "^10.4.23",
     "eslint": "^9.39.2",
     "eslint-plugin-vue": "^10.7.0",
     "globals": "^17.0.0",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.18",
     "vite": "^6.0.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}

--- a/src-tauri/src/commands/db.rs
+++ b/src-tauri/src/commands/db.rs
@@ -21,3 +21,10 @@ pub fn record_tokens(
     let conn = state.db.lock().map_err(|e| e.to_string())?;
     db::record_tokens(&conn, &date, prompt, completion, &model).map_err(|e| e.to_string())
 }
+
+/// Command to clear all application data (currently just token statistics).
+#[tauri::command]
+pub fn clear_all_data(state: State<'_, AppState>) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    db::clear_database(&conn).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/ollama.rs
+++ b/src-tauri/src/commands/ollama.rs
@@ -43,3 +43,16 @@ pub async fn start_model(state: State<'_, AppState>, name: String) -> Result<(),
 pub async fn unload_model(state: State<'_, AppState>, name: String) -> Result<(), String> {
     state.ollama.unload_model(name).await.map_err(|e| e.to_string())
 }
+
+/// Command to update the Ollama API endpoint.
+#[tauri::command]
+pub async fn update_ollama_config(state: State<'_, AppState>, endpoint: String) -> Result<(), String> {
+    state.ollama.set_base_url(endpoint);
+    Ok(())
+}
+
+/// Command to test the connection to an Ollama endpoint.
+#[tauri::command]
+pub async fn check_connection(state: State<'_, AppState>) -> Result<(), String> {
+    state.ollama.get_tags().await.map(|_| ()).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -67,5 +67,12 @@ pub fn get_aggregated_stats(conn: &Connection) -> Result<Vec<TokenStat>> {
     for row in rows {
         stats.push(row.context("Failed to read row")?);
     }
-    Ok(stats)
-}
+        Ok(stats)
+    }
+    
+    /// Delete all records from the token_stats table.
+    pub fn clear_database(conn: &Connection) -> Result<()> {
+        conn.execute("DELETE FROM token_stats", []).context("Failed to clear database")?;
+        Ok(())
+    }
+    

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,8 +35,11 @@ pub fn run() {
             commands::ollama::pull_model,
             commands::ollama::start_model,
             commands::ollama::unload_model,
+            commands::ollama::update_ollama_config,
+            commands::ollama::check_connection,
             commands::db::get_token_stats,
             commands::db::record_tokens,
+            commands::db::clear_all_data,
             commands::system::get_gpu_info
         ])
         .run(tauri::generate_context!())

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,4 +1,18 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+@import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+SC:wght@400;500;700&display=swap');
+
+@theme {
+  --color-primary: var(--primary-color);
+  --color-primary-hover: var(--primary-hover);
+  
+  --color-bg-app: var(--bg-app);
+  --color-bg-sidebar: var(--bg-sidebar);
+  --color-bg-panel: var(--bg-panel);
+  --color-bg-hover: var(--bg-hover);
+
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+}
 
 :root {
   /* Geek Light Theme Variables */
@@ -11,7 +25,7 @@
   --text-secondary: #6c757d;
   --text-code: #d63384;
   
-  --border-color: #dee2e6;
+  --border-color: #adb5bd;
   
   --primary-color: #0d6efd; /* Tech Blue */
   --primary-hover: #0b5ed7;
@@ -19,24 +33,49 @@
   --danger-color: #dc3545;
   --warning-color: #ffc107;
 
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-sans: 'Inter', 'Noto Sans SC', -apple-system, BlinkMacSystemFont, "PingFang SC", "Source Han Sans SC", "Noto Sans CJK SC", "Microsoft YaHei", sans-serif;
   --font-mono: 'JetBrains Mono', 'Courier New', Courier, monospace;
   
-  --radius-sm: 4px;
-  --radius-md: 6px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
   
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.dark {
+  /* Geek Dark Theme Variables (Dark Dimmed) */
+  --bg-app: #1c2128;
+  --bg-sidebar: #22272e;
+  --bg-panel: #2d333b;
+  --bg-hover: #373e47;
+  
+  --text-primary: #adbac7;
+  --text-secondary: #768390;
+  --text-code: #f69d50;
+  
+  --border-color: #373e47;
+  
+  --primary-color: #316dca;
+  --primary-hover: #388bfd;
+  --success-color: #347d39;
+  --danger-color: #e5534b;
+  --warning-color: #ae7c14;
 }
 
 body {
   background-color: var(--bg-app);
   color: var(--text-primary);
   font-family: var(--font-sans);
+  font-weight: 500;
   margin: 0;
   padding: 0;
   overflow: hidden; /* Prevent body scroll, handled by layout */
-  -webkit-font-smoothing: antialiased;
+}
+
+/* Thicker font for Chinese mode */
+:root[lang="zh"] body {
+  font-weight: 600;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -44,6 +83,16 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
   color: var(--text-primary);
   margin-top: 0;
+}
+
+/* Thicker headers for Chinese mode */
+:root[lang="zh"] h1, 
+:root[lang="zh"] h2, 
+:root[lang="zh"] h3, 
+:root[lang="zh"] h4, 
+:root[lang="zh"] h5, 
+:root[lang="zh"] h6 {
+  font-weight: 700;
 }
 
 /* Utility Classes */
@@ -83,9 +132,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-outline {
-  border-color: var(--border-color);
+  border: 2px solid var(--border-color);
   color: var(--text-primary);
-  background-color: white;
+  background-color: var(--bg-panel);
 }
 .btn-outline:hover {
   background-color: var(--bg-hover);
@@ -95,7 +144,7 @@ h1, h2, h3, h4, h5, h6 {
 .btn-danger {
   background-color: var(--danger-color);
   color: white;
-  border: 1px solid var(--danger-color);
+  border: 2px solid var(--danger-color);
 }
 .btn-danger:hover {
   background-color: #bb2d3b;
@@ -117,9 +166,9 @@ h1, h2, h3, h4, h5, h6 {
 input, select, textarea {
   font-family: var(--font-sans);
   padding: 8px 12px;
-  border: 1px solid var(--border-color);
+  border: 2px solid var(--border-color);
   border-radius: var(--radius-sm);
-  background-color: white;
+  background-color: var(--bg-panel);
   color: var(--text-primary);
   font-size: 14px;
   outline: none;
@@ -134,14 +183,15 @@ input:focus, select:focus, textarea:focus {
 /* Cards / Panels */
 .panel {
   background: var(--bg-panel);
-  border: 1px solid var(--border-color);
+  border: 2px solid var(--border-color);
   border-radius: var(--radius-md);
+  overflow: hidden;
   /* box-shadow: var(--shadow-sm); removed for flatter geek look */
 }
 
 .panel-header {
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 2px solid var(--border-color);
   background: var(--bg-sidebar); /* Subtle contrast */
   font-weight: 600;
   font-size: 14px;

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -25,6 +25,63 @@
         Home
       </router-link>
       <router-link
+        to="/chat"
+        class="nav-item"
+        active-class="active"
+      >
+        <span class="icon-box">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
+        </span>
+        Chat
+      </router-link>
+      <router-link
+        to="/dashboard"
+        class="nav-item"
+        active-class="active"
+      >
+        <span class="icon-box">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><rect
+            x="3"
+            y="3"
+            width="18"
+            height="18"
+            rx="2"
+            ry="2"
+          /><line
+            x1="3"
+            y1="9"
+            x2="21"
+            y2="9"
+          /><line
+            x1="9"
+            y1="21"
+            x2="9"
+            y2="9"
+          /></svg>
+        </span>
+        Dashboard
+      </router-link>
+      <router-link
         to="/models"
         class="nav-item"
         active-class="active"
@@ -81,7 +138,7 @@
 .sidebar {
   width: 240px;
   background-color: var(--bg-sidebar);
-  border-right: 1px solid var(--border-color);
+  border-right: 2px solid var(--border-color);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -93,7 +150,7 @@
   font-size: 16px;
   font-weight: 600;
   color: var(--text-primary);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 2px solid var(--border-color);
   letter-spacing: -0.5px;
   display: flex;
   align-items: center;

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -75,22 +75,24 @@ function close() {
 <style scoped>
 .titlebar {
   height: 32px;
-  background: #2f3241;
+  background: var(--bg-sidebar);
+  border-bottom: 2px solid var(--border-color);
   user-select: none;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
   z-index: 1000;
-  color: white;
+  color: var(--text-primary);
 }
 
 .title {
   margin-left: 15px;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 500;
   pointer-events: none; /* Let clicks pass through to drag region */
 }
 
@@ -102,7 +104,7 @@ function close() {
 .control-btn {
   background: transparent;
   border: none;
-  color: white;
+  color: var(--text-primary);
   width: 46px;
   height: 100%;
   display: flex;
@@ -114,11 +116,12 @@ function close() {
 }
 
 .control-btn:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--bg-hover);
 }
 
 .control-btn.close:hover {
   background-color: #e81123;
+  color: white;
 }
 
 .control-btn svg {

--- a/src/components/TokenChart.vue
+++ b/src/components/TokenChart.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="panel mt-4">
     <div class="panel-header">
-      <span>Token Usage Trend</span>
+      <span>{{ t.title }}</span>
       <div class="legend">
-        <span class="dot primary" /> Input
-        <span class="dot success ml-2" /> Output
+        <span class="dot primary" /> {{ t.input }}
+        <span class="dot success ml-2" /> {{ t.output }}
       </div>
     </div>
     <div class="panel-body">
@@ -17,15 +17,32 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import * as echarts from 'echarts'
 import { invoke } from '@tauri-apps/api/core'
+import { useSettingsStore } from '../store/settings'
 
 /**
  * TokenChart component visualizes input and output token usage over time using ECharts.
  */
 const chartRef = ref(null)
+const settings = useSettingsStore()
 let chart = null
+
+const translations = {
+  en: {
+    title: 'Token Usage Trend',
+    input: 'Input',
+    output: 'Output'
+  },
+  zh: {
+    title: 'Token 使用趋势',
+    input: '提示词 (Input)',
+    output: '生成词 (Output)'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
 
 /**
  * Fetches token statistics from the backend and updates the chart.
@@ -68,7 +85,7 @@ const updateChart = async () => {
       },
       series: [
         {
-          name: 'Input',
+          name: t.value.input,
           type: 'line',
           data: promptTokens,
           smooth: true,
@@ -78,7 +95,7 @@ const updateChart = async () => {
           lineStyle: { width: 2 }
         },
         {
-          name: 'Output',
+          name: t.value.output,
           type: 'line',
           data: completionTokens,
           smooth: true,
@@ -94,6 +111,10 @@ const updateChart = async () => {
     console.error('Failed to update chart:', error)
   }
 }
+
+watch(() => settings.language, () => {
+  updateChart()
+})
 
 onMounted(() => {
   // Initialize chart instance

--- a/src/components/common/FeatureCard.vue
+++ b/src/components/common/FeatureCard.vue
@@ -1,0 +1,119 @@
+<template>
+  <div
+    class="feature-card panel clickable"
+    @click="$emit('click')"
+  >
+    <div class="panel-body">
+      <div class="card-icon">
+        <slot name="icon" />
+      </div>
+      <div class="card-content">
+        <h3 class="card-title">
+          {{ title }}
+        </h3>
+        <p class="card-description">
+          {{ description }}
+        </p>
+      </div>
+      <div class="card-arrow">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ><line
+          x1="5"
+          y1="12"
+          x2="19"
+          y2="12"
+        /><polyline points="12 5 19 12 12 19" /></svg>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Common component for feature cards displayed on the home page.
+ */
+defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  description: {
+    type: String,
+    required: true
+  }
+})
+
+defineEmits(['click'])
+</script>
+
+<style scoped>
+.feature-card {
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  border: 1px solid var(--border-color);
+  height: 100%;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-color);
+  box-shadow: var(--shadow-md);
+}
+
+.panel-body {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 24px;
+}
+
+.card-icon {
+  font-size: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  background-color: var(--bg-secondary);
+  border-radius: var(--radius-md);
+}
+
+.card-content {
+  flex: 1;
+}
+
+.card-title {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+  color: var(--text-primary);
+}
+
+.card-description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.card-arrow {
+  color: var(--text-muted);
+  transition: transform 0.2s ease;
+}
+
+.feature-card:hover .card-arrow {
+  color: var(--primary-color);
+  transform: translateX(4px);
+}
+
+.clickable {
+  cursor: pointer;
+}
+</style>

--- a/src/components/models/ModelItem.vue
+++ b/src/components/models/ModelItem.vue
@@ -1,31 +1,38 @@
 <template>
   <div class="list-item">
-    <div class="item-info">
-      <div class="item-name text-mono">
+    <!-- Icon Column -->
+    <div class="item-icon-col">
+      <div class="icon-box">
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          width="14"
-          height="14"
+          width="24"
+          height="24"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
-          stroke-width="2"
+          stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
-          class="text-muted mr-1"
-          style="vertical-align: middle;"
         ><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><polyline points="3.27 6.96 12 12.01 20.73 6.96" /><line
           x1="12"
           y1="22.08"
           x2="12"
           y2="12"
         /></svg>
+      </div>
+    </div>
+
+    <!-- Info Column (Name & Size) -->
+    <div class="item-info">
+      <div class="item-name text-mono">
         {{ model.name }}
       </div>
       <div class="item-meta text-muted">
         {{ formatSize(model.size) }}
       </div>
     </div>
+
+    <!-- Actions Column -->
     <div class="item-actions">
       <!-- Start/Running Status Button -->
       <button 
@@ -35,7 +42,7 @@
         @click="$emit('start', model.name)"
       >
         <template v-if="loadingState === 'starting'">
-          ⏳ Starting...
+          ⏳ {{ t.starting }}
         </template>
         <template v-else-if="isRunning">
           <svg
@@ -49,7 +56,7 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           ><polyline points="20 6 9 17 4 12" /></svg>
-          Running
+          {{ t.running }}
         </template>
         <template v-else>
           <svg
@@ -63,7 +70,7 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           ><polygon points="5 3 19 12 5 21 5 3" /></svg>
-          Start
+          {{ t.start }}
         </template>
       </button>
       
@@ -84,13 +91,16 @@
           stroke-linecap="round"
           stroke-linejoin="round"
         ><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
-        {{ loadingState === 'deleting' ? '...' : 'Delete' }}
+        {{ loadingState === 'deleting' ? '...' : t.delete }}
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useSettingsStore } from '../../store/settings'
+
 /**
  * ModelItem component displays a single model's information and action buttons.
  */
@@ -108,6 +118,25 @@ defineProps({
     default: null
   }
 })
+
+const settings = useSettingsStore()
+
+const translations = {
+  en: {
+    starting: 'Starting...',
+    running: 'Running',
+    start: 'Start',
+    delete: 'Delete'
+  },
+  zh: {
+    starting: '启动中...',
+    running: '运行中',
+    start: '启动',
+    delete: '删除'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
 
 defineEmits(['start', 'delete'])
 
@@ -127,10 +156,10 @@ const formatSize = (bytes) => {
 <style scoped>
 .list-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--border-color);
+  padding: 16px 16px; /* Increased padding for spaciousness */
+  border-bottom: 2px solid var(--border-color);
+  gap: 16px;
 }
 
 .list-item:last-child {
@@ -142,26 +171,49 @@ const formatSize = (bytes) => {
   padding-top: 0;
 }
 
+/* Icon Column Styles */
+.item-icon-col {
+  flex-shrink: 0;
+}
+
+.icon-box {
+  width: 48px;
+  height: 48px;
+  background-color: var(--bg-hover);
+  border-radius: var(--radius-md); /* Smooth rounded icon container */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary-color);
+}
+
+/* Info Column Styles */
 .item-info {
   flex: 1;
   min-width: 0;
-  margin-right: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px; /* Space between name and size */
 }
 
 .item-name {
-  font-weight: 500;
-  font-size: 14px;
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 1.2;
 }
 
 .item-meta {
-  font-size: 12px;
-  margin-top: 2px;
-  margin-left: 20px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1;
 }
 
+/* Actions Column Styles */
 .item-actions {
   flex-shrink: 0;
   display: flex;
@@ -169,7 +221,6 @@ const formatSize = (bytes) => {
 }
 
 .mr-2 { margin-right: 8px; }
-.mr-1 { margin-right: 4px; }
 .d-flex { display: flex; align-items: center; }
 .gap-1 { gap: 4px; }
 </style>

--- a/src/components/models/ModelList.vue
+++ b/src/components/models/ModelList.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="panel mb-4">
     <div class="panel-header">
-      <span class="d-flex gap-2">📦 Installed Models</span>
+      <span class="d-flex gap-2">📦 {{ t.title }}</span>
       <span
         class="text-muted text-mono"
         style="font-size: 12px"
-      >{{ models.length }} items</span>
+      >{{ models.length }} {{ t.items }}</span>
     </div>
     <div class="panel-body">
       <!-- Pull Model Input -->
       <div class="d-flex gap-2 mb-3">
         <input 
           v-model="newModelName" 
-          placeholder="Pull model (e.g. llama3)" 
+          :placeholder="t.placeholder" 
           style="flex: 1"
           @keyup.enter="handlePull"
         >
@@ -37,7 +37,7 @@
             x2="12"
             y2="3"
           /></svg>
-          {{ pulling ? 'Pulling...' : 'Pull' }}
+          {{ pulling ? t.pulling : t.pull }}
         </button>
       </div>
 
@@ -66,7 +66,7 @@
         <div class="spinner mb-2">
           ⏳
         </div>
-        Loading library...
+        {{ t.loading }}
       </div>
       <div
         v-else
@@ -87,7 +87,8 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useSettingsStore } from '../../store/settings'
 import ModelItem from './ModelItem.vue'
 
 /**
@@ -119,6 +120,29 @@ const props = defineProps({
     default: () => ({})
   }
 })
+
+const settings = useSettingsStore()
+
+const translations = {
+  en: {
+    title: 'Installed Models',
+    items: 'items',
+    placeholder: 'Pull model (e.g. llama3)',
+    pull: 'Pull',
+    pulling: 'Pulling...',
+    loading: 'Loading library...'
+  },
+  zh: {
+    title: '已安装模型',
+    items: '个项目',
+    placeholder: '拉取模型 (例如 llama3)',
+    pull: '拉取',
+    pulling: '拉取中...',
+    loading: '正在加载模型库...'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
 
 const emit = defineEmits(['pull', 'start', 'delete'])
 

--- a/src/components/models/RunningProcesses.vue
+++ b/src/components/models/RunningProcesses.vue
@@ -4,7 +4,7 @@
       class="panel-header"
       style="justify-content: space-between; align-items: center;"
     >
-      <span class="d-flex gap-2">🚀 Running Processes</span>
+      <span class="d-flex gap-2">🚀 {{ t.title }}</span>
       
       <!-- GPU Info Section -->
       <div
@@ -42,7 +42,7 @@
         v-else
         class="text-success text-mono"
         style="font-size: 12px"
-      >Active</span>
+      >{{ t.active }}</span>
     </div>
     
     <div class="panel-body">
@@ -54,7 +54,7 @@
         <div style="font-size: 24px; margin-bottom: 8px;">
           😴
         </div>
-        No models currently running.
+        {{ t.noModels }}
       </div>
       
       <!-- Running Models List -->
@@ -67,15 +67,36 @@
           :key="model.name"
           class="list-item"
         >
-          <div class="item-info">
-            <div class="item-name text-mono text-primary d-flex gap-2">
-              <span class="status-dot" />
+          <!-- Left side: Icon & Name -->
+          <div class="item-main-info">
+            <div class="mini-icon-box">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><polyline points="3.27 6.96 12 12.01 20.73 6.96" /><line
+                x1="12"
+                y1="22.08"
+                x2="12"
+                y2="12"
+              /></svg>
+            </div>
+            <div class="item-name text-mono text-primary">
               {{ model.name }}
             </div>
-            <div class="item-meta text-muted">
-              VRAM: {{ formatSize(model.size_vram) }}
+            <div class="status-indicator">
+              <span class="status-dot" />
+              <span class="status-text text-success">{{ t.active }}</span>
             </div>
           </div>
+
+          <!-- Right side: Actions -->
           <div class="item-actions">
             <button 
               class="btn btn-sm btn-danger d-flex gap-1" 
@@ -83,7 +104,7 @@
               @click="$emit('stop', model.name)"
             >
               <template v-if="loadingStates[model.name] === 'stopping'">
-                ⏳ Stopping...
+                ⏳ {{ t.stopping }}
               </template>
               <template v-else>
                 <svg
@@ -104,7 +125,7 @@
                   rx="2"
                   ry="2"
                 /></svg>
-                Stop
+                {{ t.stop }}
               </template>
             </button>
           </div>
@@ -115,6 +136,9 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useSettingsStore } from '../../store/settings'
+
 /**
  * RunningProcesses component shows currently active models and system resource usage.
  */
@@ -132,6 +156,29 @@ defineProps({
     default: () => ({})
   }
 })
+
+const settings = useSettingsStore()
+
+const translations = {
+  en: {
+    title: 'Running Processes',
+    active: 'Active',
+    noModels: 'No models currently running.',
+    vram: 'VRAM',
+    stop: 'Stop',
+    stopping: 'Stopping...'
+  },
+  zh: {
+    title: '运行中的进程',
+    active: '活跃',
+    noModels: '当前没有正在运行的模型。',
+    vram: '显存占用',
+    stop: '停止',
+    stopping: '停止中...'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
 
 defineEmits(['stop'])
 
@@ -163,8 +210,8 @@ const formatSize = (bytes) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--border-color);
+  padding: 16px 12px;
+  border-bottom: 2px solid var(--border-color);
 }
 
 .list-item:last-child {
@@ -172,24 +219,44 @@ const formatSize = (bytes) => {
   padding-bottom: 0;
 }
 
-.item-info {
+.item-main-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   flex: 1;
   min-width: 0;
-  margin-right: 16px;
+}
+
+.mini-icon-box {
+  width: 32px;
+  height: 32px;
+  background-color: var(--bg-hover);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary-color);
+  flex-shrink: 0;
 }
 
 .item-name {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 14px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.item-meta {
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.status-text {
   font-size: 12px;
-  margin-top: 2px;
-  margin-left: 20px;
+  font-weight: 500;
 }
 
 .status-dot {

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,13 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import App from './App.vue'
 import router from './router'
 import './assets/main.css'
 
 const app = createApp(App)
 const pinia = createPinia()
+pinia.use(piniaPluginPersistedstate)
 
 app.use(pinia)
 app.use(router)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,16 @@ const routes = [
     component: () => import('../views/HomeView.vue')
   },
   {
+    path: '/chat',
+    name: 'Chat',
+    component: () => import('../views/ChatView.vue')
+  },
+  {
+    path: '/dashboard',
+    name: 'Dashboard',
+    component: () => import('../views/DashboardView.vue')
+  },
+  {
     path: '/models',
     name: 'Models',
     component: () => import('../views/ModelsView.vue')

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -1,0 +1,92 @@
+import { defineStore } from 'pinia'
+import { invoke } from '@tauri-apps/api/core'
+
+/**
+ * Pinia store for managing application settings.
+ * Persists data to localStorage via pinia-plugin-persistedstate.
+ */
+export const useSettingsStore = defineStore('settings', {
+  state: () => ({
+    theme: 'system', // 'light', 'dark', 'system'
+    language: 'zh', // 'en', 'zh'
+    ollamaEndpoint: 'http://127.0.0.1:11434',
+  }),
+
+  actions: {
+    /**
+     * Initializes the application settings (theme and language).
+     */
+    init() {
+      this.applyTheme(this.theme)
+      this.applyLanguage(this.language)
+    },
+
+    /**
+     * Updates the theme and applies it to the document.
+     * @param {string} theme - The theme to apply ('light', 'dark', or 'system').
+     */
+    setTheme(theme) {
+      this.theme = theme
+      this.applyTheme(theme)
+    },
+
+    /**
+     * Applies the specified theme to the HTML document.
+     * @param {string} theme - The theme to apply.
+     */
+    applyTheme(theme) {
+      const html = document.documentElement
+      if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        html.classList.add('dark')
+      } else {
+        html.classList.remove('dark')
+      }
+    },
+
+    /**
+     * Updates the language setting and applies it to the document.
+     * @param {string} lang - The language code ('en' or 'zh').
+     */
+    setLanguage(lang) {
+      this.language = lang
+      this.applyLanguage(lang)
+    },
+
+    /**
+     * Applies the language attribute to the HTML document.
+     * @param {string} lang 
+     */
+    applyLanguage(lang) {
+      document.documentElement.setAttribute('lang', lang)
+    },
+
+    /**
+     * Updates the Ollama endpoint and notifies the backend.
+     * @param {string} endpoint - The new Ollama API endpoint.
+     */
+    async setOllamaEndpoint(endpoint) {
+      this.ollamaEndpoint = endpoint
+      try {
+        await invoke('update_ollama_config', { endpoint })
+      } catch (error) {
+        console.error('Failed to update Ollama config in backend:', error)
+      }
+    },
+
+    /**
+     * Syncs current settings to the backend.
+     * Useful on application startup.
+     */
+    async syncToBackend() {
+      try {
+        await invoke('update_ollama_config', { endpoint: this.ollamaEndpoint })
+      } catch (error) {
+        console.error('Failed to sync settings to backend:', error)
+      }
+    }
+  },
+
+  persist: {
+    key: 'ai-toolbox-settings',
+  },
+})

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1,0 +1,366 @@
+<template>
+  <div class="chat-view-container">
+    <div
+      ref="messagesRef"
+      class="messages"
+    >
+      <div
+        v-for="(msg, index) in messages"
+        :key="index"
+        :class="['message-wrapper', msg.role]"
+      >
+        <div class="message-row">
+          <div
+            v-if="msg.role === 'assistant'"
+            class="avatar"
+          >
+            🤖
+          </div>
+          
+          <div class="content-column">
+            <div class="message-meta">
+              <span
+                class="role-badge text-mono"
+                :class="msg.role"
+              >{{ msg.role === 'user' ? t.you : t.ai }}</span>
+            </div>
+            <div class="message-bubble panel">
+              <div class="panel-body">
+                {{ msg.content }}
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="msg.role === 'user'"
+            class="avatar"
+          >
+            👤
+          </div>
+        </div>
+      </div>
+      
+      <div
+        v-if="loading"
+        class="message-wrapper assistant"
+      >
+        <div class="message-row">
+          <div class="avatar">
+            🤖
+          </div>
+          <div class="content-column">
+            <div class="message-meta">
+              <span class="role-badge assistant text-mono">{{ t.ai }}</span>
+            </div>
+            <div class="message-bubble panel">
+              <div class="panel-body text-muted">
+                <span class="typing-indicator">{{ t.thinking }} 💭</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="input-area panel">
+      <div
+        class="panel-header"
+        style="background: transparent; padding: 8px 12px; border-bottom: none;"
+      >
+        <select
+          v-model="store.selectedModel"
+          class="model-select"
+          @change="store.selectModel($event.target.value)"
+        >
+          <option
+            disabled
+            value=""
+          >
+            {{ t.selectModel }}
+          </option>
+          <option
+            v-for="model in store.models"
+            :key="model.name"
+            :value="model.name"
+          >
+            {{ model.name }}
+          </option>
+        </select>
+      </div>
+      <div
+        class="panel-body"
+        style="padding: 0 12px 12px 12px;"
+      >
+        <div class="input-wrapper">
+          <textarea 
+            v-model="input" 
+            :placeholder="t.placeholder" 
+            :disabled="loading"
+            rows="3"
+            @keydown.enter.prevent="sendMessage"
+          />
+          <button
+            :disabled="loading || !store.selectedModel"
+            class="btn btn-primary send-btn"
+            @click="sendMessage"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ><line
+              x1="22"
+              y1="2"
+              x2="11"
+              y2="13"
+            /><polygon points="22 2 15 22 11 13 2 9 22 2" /></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Chat view component for interacting with models.
+ */
+import { ref, onMounted, nextTick, computed } from 'vue'
+import { useModelStore } from '../store/models'
+import { useSettingsStore } from '../store/settings'
+import { invoke } from '@tauri-apps/api/core'
+
+const store = useModelStore()
+const settings = useSettingsStore()
+const input = ref('')
+const messages = ref([])
+const loading = ref(false)
+const messagesRef = ref(null)
+
+const translations = {
+  en: {
+    you: 'YOU',
+    ai: 'AI',
+    thinking: 'Thinking...',
+    selectModel: 'Select Model',
+    placeholder: 'Type your message here...',
+    errorMessage: 'Error: '
+  },
+  zh: {
+    you: '您',
+    ai: 'AI',
+    thinking: '正在思考...',
+    selectModel: '选择模型',
+    placeholder: '输入消息...',
+    errorMessage: '错误: '
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
+
+/**
+ * Sends a message to the selected Ollama model.
+ */
+const sendMessage = async () => {
+  if (!input.value.trim() || !store.selectedModel) return
+
+  const userMsg = input.value
+  messages.value.push({ role: 'user', content: userMsg })
+  input.value = ''
+  loading.value = true
+  
+  await scrollToBottom()
+
+  try {
+    const endpoint = settings.ollamaEndpoint.endsWith('/') 
+      ? `${settings.ollamaEndpoint}api/generate` 
+      : `${settings.ollamaEndpoint}/api/generate`
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({
+        model: store.selectedModel,
+        prompt: userMsg,
+        stream: false
+      })
+    })
+    
+    const data = await response.json()
+    messages.value.push({ role: 'assistant', content: data.response })
+    
+    const today = new Date().toISOString().split('T')[0]
+    await invoke('record_tokens', {
+      date: today,
+      prompt: data.prompt_eval_count || 0,
+      completion: data.eval_count || 0,
+      model: store.selectedModel
+    })
+    
+  } catch (error) {
+    messages.value.push({ role: 'assistant', content: t.value.errorMessage + error })
+  } finally {
+    loading.value = false
+    await scrollToBottom()
+  }
+}
+
+/**
+ * Scrolls the message container to the bottom.
+ */
+const scrollToBottom = async () => {
+  await nextTick()
+  if (messagesRef.value) {
+    messagesRef.value.scrollTop = messagesRef.value.scrollHeight
+  }
+}
+
+onMounted(async () => {
+  await store.fetchModels()
+  if (!store.selectedModel && store.models.length > 0) {
+    store.selectModel(store.models[0].name)
+  }
+})
+</script>
+
+<style scoped>
+.chat-view-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 24px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 24px;
+  padding-right: 8px;
+}
+
+.message-wrapper {
+  margin-bottom: 24px;
+}
+
+.message-row {
+  display: flex;
+  gap: 12px;
+  max-width: 80%;
+}
+
+.message-wrapper.user .message-row {
+  flex-direction: row;
+  margin-left: auto;
+  justify-content: flex-end;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  background-color: white;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  flex-shrink: 0;
+  box-shadow: var(--shadow-sm);
+}
+
+.content-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.message-wrapper.user .content-column {
+  align-items: flex-end;
+}
+
+.message-meta {
+  margin-bottom: 4px;
+}
+
+.role-badge {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.message-bubble {
+  background: white;
+  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-md);
+  position: relative;
+}
+
+.message-wrapper.assistant .message-bubble {
+  border-top-left-radius: 0;
+}
+
+.message-wrapper.user .message-bubble {
+  background: #f1f8ff;
+  border-color: #cce5ff;
+  border-top-right-radius: 0;
+}
+
+.input-area {
+  flex-shrink: 0;
+  border-color: var(--primary-color);
+  box-shadow: var(--shadow-md);
+}
+
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+}
+
+textarea {
+  width: 100%;
+  border: none;
+  background: transparent;
+  resize: none;
+  font-family: var(--font-sans);
+  padding-right: 40px;
+}
+
+textarea:focus {
+  box-shadow: none;
+}
+
+.send-btn {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding: 8px;
+  background: transparent;
+  color: var(--primary-color);
+  border: none;
+}
+
+.send-btn:hover {
+  background: var(--bg-hover);
+  color: var(--primary-hover);
+}
+
+.send-btn:disabled {
+  color: var(--text-secondary);
+}
+
+.model-select {
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding-left: 0;
+}
+</style>

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="dashboard-view">
+    <div class="header-section mb-4">
+      <h1>{{ t.title }}</h1>
+      <p class="text-muted">
+        {{ t.subtitle }}
+      </p>
+    </div>
+
+    <div class="stats-overview grid-3 mb-4">
+      <div class="panel stat-card">
+        <div class="panel-body">
+          <div class="stat-label">
+            {{ t.totalPrompt }}
+          </div>
+          <div class="stat-value text-primary">
+            {{ totalPrompt }}
+          </div>
+        </div>
+      </div>
+      <div class="panel stat-card">
+        <div class="panel-body">
+          <div class="stat-label">
+            {{ t.totalCompletion }}
+          </div>
+          <div class="stat-value text-success">
+            {{ totalCompletion }}
+          </div>
+        </div>
+      </div>
+      <div class="panel stat-card">
+        <div class="panel-body">
+          <div class="stat-label">
+            {{ t.activeDays }}
+          </div>
+          <div class="stat-value">
+            {{ activeDays }}
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <TokenChart />
+  </div>
+</template>
+
+<script setup>
+/**
+ * Dashboard view providing detailed usage analytics and statistics.
+ */
+import { ref, onMounted, computed } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import { useSettingsStore } from '../store/settings'
+import TokenChart from '../components/TokenChart.vue'
+
+const settings = useSettingsStore()
+const totalPrompt = ref(0)
+const totalCompletion = ref(0)
+const activeDays = ref(0)
+
+const translations = {
+  en: {
+    title: 'Usage Analytics',
+    subtitle: 'Visualize your model interactions and token consumption over time.',
+    totalPrompt: 'Total Prompt Tokens',
+    totalCompletion: 'Total Completion Tokens',
+    activeDays: 'Days Active'
+  },
+  zh: {
+    title: '用量分析',
+    subtitle: '可视化您的模型交互和随时间变化的 Token 消耗。',
+    totalPrompt: '总提示词 Token',
+    totalCompletion: '总生成词 Token',
+    activeDays: '活跃天数'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
+
+/**
+ * Fetches and calculates summary statistics from the token history.
+ */
+const fetchStats = async () => {
+  try {
+    const stats = await invoke('get_token_stats')
+    totalPrompt.value = stats.reduce((acc, curr) => acc + curr.prompt_tokens, 0).toLocaleString()
+    totalCompletion.value = stats.reduce((acc, curr) => acc + curr.completion_tokens, 0).toLocaleString()
+    activeDays.value = stats.length
+  } catch (error) {
+    console.error('Failed to fetch stats:', error)
+  }
+}
+
+onMounted(() => {
+  fetchStats()
+})
+</script>
+
+<style scoped>
+.dashboard-view {
+  padding: 32px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.mb-4 { margin-bottom: 32px; }
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.stat-card {
+  text-align: center;
+}
+
+.stat-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+
+@media (max-width: 768px) {
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,467 +1,284 @@
 <template>
-  <div class="chat-container">
-    <div
-      ref="messagesRef"
-      class="messages"
-    >
-      <div
-        v-for="(msg, index) in messages"
-        :key="index"
-        :class="['message-wrapper', msg.role]"
-      >
-        <div class="message-row">
-          <div
-            v-if="msg.role === 'assistant'"
-            class="avatar"
-          >
-            🤖
-          </div>
-          
-          <div class="content-column">
-            <div class="message-meta">
-              <span
-                class="role-badge text-mono"
-                :class="msg.role"
-              >{{ msg.role === 'user' ? 'YOU' : 'AI' }}</span>
-            </div>
-            <div class="message-bubble panel">
-              <div class="panel-body">
-                {{ msg.content }}
-              </div>
-            </div>
-          </div>
-
-          <div
-            v-if="msg.role === 'user'"
-            class="avatar"
-          >
-            👤
-          </div>
+  <div class="home-container">
+    <header class="home-header">
+      <div class="hero-section">
+        <div class="logo-animation">
+          <span class="emoji-switcher">{{ currentEmoji }}</span>
         </div>
-      </div>
-      
-      <div
-        v-if="loading"
-        class="message-wrapper assistant"
-      >
-        <div class="message-row">
-          <div class="avatar">
-            🤖
-          </div>
-          <div class="content-column">
-            <div class="message-meta">
-              <span class="role-badge assistant text-mono">AI</span>
-            </div>
-            <div class="message-bubble panel">
-              <div class="panel-body text-muted">
-                <span class="typing-indicator">Thinking... 💭</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="input-area panel">
-      <div
-        class="panel-header"
-        style="background: transparent; padding: 8px 12px; border-bottom: none;"
-      >
-        <select
-          v-model="store.selectedModel"
-          class="model-select"
-          @change="store.selectModel($event.target.value)"
-        >
-          <option
-            disabled
-            value=""
-          >
-            Select Model
-          </option>
-          <option
-            v-for="model in store.models"
-            :key="model.name"
-            :value="model.name"
-          >
-            {{ model.name }}
-          </option>
-        </select>
-      </div>
-      <div
-        class="panel-body"
-        style="padding: 0 12px 12px 12px;"
-      >
-        <div class="input-wrapper">
-          <textarea 
-            v-model="input" 
-            placeholder="Type your message here..." 
-            :disabled="loading"
-            rows="3"
-            @keydown.enter.prevent="sendMessage"
-          />
+        <h1 class="slogan">
+          <span
+            v-for="(char, index) in sloganChars"
+            :key="index"
+            class="bouncing-char"
+            :style="{ 
+              animationDelay: `${index * 0.1}s`,
+              color: index < 7 ? 'var(--primary-color)' : 'inherit'
+            }"
+          >{{ char === ' ' ? '&nbsp;' : char }}</span>
+        </h1>
+        <p class="app-description">
+          {{ t.description }}
+        </p>
+        <div class="header-actions">
           <button
-            :disabled="loading || !store.selectedModel"
-            class="btn btn-primary send-btn"
-            @click="sendMessage"
+            class="btn btn-primary btn-lg"
+            @click="router.push('/chat')"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ><line
-              x1="22"
-              y1="2"
-              x2="11"
-              y2="13"
-            /><polygon points="22 2 15 22 11 13 2 9 22 2" /></svg>
+            {{ t.startChat }}
+          </button>
+          <button
+            class="btn btn-outline btn-lg"
+            @click="router.push('/models')"
+          >
+            {{ t.manageModels }}
           </button>
         </div>
       </div>
+    </header>
+
+    <div class="section-divider">
+      <span class="divider-text">{{ t.exploreFeatures }}</span>
     </div>
+
+    <main class="feature-grid">
+      <FeatureCard
+        :title="t.featureChatTitle"
+        :description="t.featureChatDesc"
+        @click="router.push('/chat')"
+      >
+        <template #icon>
+          💬
+        </template>
+      </FeatureCard>
+
+      <FeatureCard
+        :title="t.featureModelsTitle"
+        :description="t.featureModelsDesc"
+        @click="router.push('/models')"
+      >
+        <template #icon>
+          📦
+        </template>
+      </FeatureCard>
+
+      <FeatureCard
+        :title="t.featureStatsTitle"
+        :description="t.featureStatsDesc"
+        @click="router.push('/dashboard')"
+      >
+        <template #icon>
+          📊
+        </template>
+      </FeatureCard>
+
+      <FeatureCard
+        :title="t.featureSettingsTitle"
+        :description="t.featureSettingsDesc"
+        @click="router.push('/settings')"
+      >
+        <template #icon>
+          ⚙️
+        </template>
+      </FeatureCard>
+    </main>
+
+    <footer class="home-footer">
+      <p class="text-muted">
+        {{ t.footer }}
+      </p>
+    </footer>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick } from 'vue'
-import { useModelStore } from '../store/models'
-import { invoke } from '@tauri-apps/api/core'
+/**
+ * Refined Home view with enhanced animations, professional descriptions, 
+ * and improved visual hierarchy.
+ */
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSettingsStore } from '../store/settings'
+import FeatureCard from '../components/common/FeatureCard.vue'
 
-const store = useModelStore()
-const input = ref('')
-const messages = ref([])
-const loading = ref(false)
-const messagesRef = ref(null)
+const router = useRouter()
+const settings = useSettingsStore()
 
-const sendMessage = async () => {
-  if (!input.value.trim() || !store.selectedModel) return
-
-  const userMsg = input.value
-  messages.value.push({ role: 'user', content: userMsg })
-  input.value = ''
-  loading.value = true
-  
-  await scrollToBottom()
-
-  try {
-    const response = await fetch('http://localhost:11434/api/generate', {
-      method: 'POST',
-      body: JSON.stringify({
-        model: store.selectedModel,
-        prompt: userMsg,
-        stream: false
-      })
-    })
-    
-    const data = await response.json()
-    messages.value.push({ role: 'assistant', content: data.response })
-    
-    const today = new Date().toISOString().split('T')[0]
-    await invoke('record_tokens', {
-      date: today,
-      prompt: data.prompt_eval_count || 0,
-      completion: data.eval_count || 0,
-      model: store.selectedModel
-    })
-    
-  } catch (error) {
-    messages.value.push({ role: 'assistant', content: 'Error: ' + error })
-  } finally {
-    loading.value = false
-    await scrollToBottom()
+const translations = {
+  en: {
+    slogan: 'Empower Your Local AI',
+    description: 'Welcome to AI Toolbox, your high-performance desktop gateway to local large language models. Manage your Ollama library, monitor real-time generation, and analyze your usage with a professional, developer-centric interface.',
+    startChat: 'Start Chatting',
+    manageModels: 'Manage Models',
+    exploreFeatures: 'EXPLORE FEATURES',
+    featureChatTitle: 'Intelligent Chat',
+    featureChatDesc: 'Connect with any local model instantly. Experience low-latency, private, and secure AI interactions.',
+    featureModelsTitle: 'Model Management',
+    featureModelsDesc: 'Seamlessly pull, update, and manage your Ollama model library with advanced monitoring.',
+    featureStatsTitle: 'Usage Analytics',
+    featureStatsDesc: 'Deep dive into your local AI consumption. Track tokens, performance, and historical trends.',
+    featureSettingsTitle: 'Advanced Settings',
+    featureSettingsDesc: 'Customize your model parameters, server connections, and application preferences.',
+    footer: 'Built for the local AI community. Powered by Tauri & Ollama.'
+  },
+  zh: {
+    slogan: '赋能您的本地 AI',
+    description: '欢迎使用 AI Toolbox，这是您通往本地大语言模型的高性能桌面门户。通过专业的、以开发者为中心的界面，管理您的 Ollama 库，监控实时生成，并分析您的使用情况。',
+    startChat: '开始对话',
+    manageModels: '管理模型',
+    exploreFeatures: '探索功能',
+    featureChatTitle: '智能对话',
+    featureChatDesc: '立即连接任何本地模型。体验低延迟、私密且安全的 AI 交互。',
+    featureModelsTitle: '模型管理',
+    featureModelsDesc: '无缝拉取、更新和管理您的 Ollama 模型库，并配有高级监控。',
+    featureStatsTitle: '用量分析',
+    featureStatsDesc: '深入了解您的本地 AI 消耗。追踪 Token、性能和历史趋势。',
+    featureSettingsTitle: '高级设置',
+    featureSettingsDesc: '自定义您的模型参数、服务器连接和应用程序首选项。',
+    footer: '为本地 AI 社区打造。由 Tauri & Ollama 驱动。'
   }
 }
 
-const scrollToBottom = async () => {
-  await nextTick()
-  if (messagesRef.value) {
-    messagesRef.value.scrollTop = messagesRef.value.scrollHeight
-  }
-}
+const t = computed(() => translations[settings.language] || translations.en)
 
-onMounted(async () => {
-  await store.fetchModels()
-  if (!store.selectedModel && store.models.length > 0) {
-    store.selectModel(store.models[0].name)
-  }
+const sloganChars = computed(() => t.value.slogan.split(''))
+
+const emojis = ['🤖', '🧠', '🚀', '🛠️', '✨', '📡', '💻', '🔮']
+const currentEmoji = ref(emojis[0])
+let emojiInterval
+
+onMounted(() => {
+  // Rotate emojis every 2 seconds with a subtle transition effect
+  emojiInterval = setInterval(() => {
+    const currentIndex = emojis.indexOf(currentEmoji.value)
+    currentEmoji.value = emojis[(currentIndex + 1) % emojis.length]
+  }, 2000)
+})
+
+onUnmounted(() => {
+  if (emojiInterval) clearInterval(emojiInterval)
 })
 </script>
 
 <style scoped>
-
-.chat-container {
-
-  display: flex;
-
-  flex-direction: column;
-
-  height: 100%;
-
-  padding: 24px;
-
-  max-width: 900px;
-
+.home-container {
+  padding: 64px 32px;
+  max-width: 1100px;
   margin: 0 auto;
-
-}
-
-
-
-.messages {
-
-  flex: 1;
-
-  overflow-y: auto;
-
-  margin-bottom: 24px;
-
-  padding-right: 8px;
-
-}
-
-
-
-.message-wrapper {
-
-  margin-bottom: 24px;
-
-}
-
-
-
-.message-row {
-
   display: flex;
-
-  gap: 12px;
-
-  max-width: 80%;
-
-}
-
-
-
-.message-wrapper.user .message-row {
-
-  flex-direction: row;
-
-  margin-left: auto;
-
-  justify-content: flex-end;
-
-}
-
-
-
-.avatar {
-
-  width: 36px;
-
-  height: 36px;
-
-  background-color: white;
-
-  border: 1px solid var(--border-color);
-
-  border-radius: 50%;
-
-  display: flex;
-
-  align-items: center;
-
-  justify-content: center;
-
-  font-size: 20px;
-
-  flex-shrink: 0;
-
-  box-shadow: var(--shadow-sm);
-
-}
-
-
-
-.content-column {
-
-  display: flex;
-
   flex-direction: column;
-
+  gap: 64px;
 }
 
-
-
-.message-wrapper.user .content-column {
-
-  align-items: flex-end;
-
+.home-header {
+  text-align: center;
 }
 
-
-
-.message-meta {
-
-  margin-bottom: 4px;
-
-}
-
-
-
-.role-badge {
-
-  font-size: 10px;
-
-  font-weight: 700;
-
-  color: var(--text-secondary);
-
-  text-transform: uppercase;
-
-}
-
-
-
-.message-bubble {
-
-  background: white;
-
-  box-shadow: var(--shadow-sm);
-
-  border-radius: var(--radius-md);
-
-  position: relative;
-
-}
-
-
-
-/* Bubbles have little tails? Maybe later. For now just clean rounded boxes. */
-
-.message-wrapper.assistant .message-bubble {
-
-  border-top-left-radius: 0;
-
-}
-
-
-
-.message-wrapper.user .message-bubble {
-
-  background: #f1f8ff; /* Very light blue for user */
-
-  border-color: #cce5ff;
-
-  border-top-right-radius: 0;
-
-}
-
-
-
-.input-area {
-
-  flex-shrink: 0;
-
-  border-color: var(--primary-color); /* Highlight input area */
-
-  box-shadow: var(--shadow-md);
-
-}
-
-
-
-.input-wrapper {
-
-  position: relative;
-
+.hero-section {
   display: flex;
-
-  align-items: flex-end;
-
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
 }
 
-
-
-textarea {
-
-  width: 100%;
-
-  border: none; /* Managed by panel */
-
-  background: transparent;
-
-  resize: none;
-
-  font-family: var(--font-sans);
-
-  padding-right: 40px; /* Space for send button */
-
+.logo-animation {
+  font-size: 72px;
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 0 20px rgba(13, 110, 253, 0.2));
 }
 
-
-
-textarea:focus {
-
-  box-shadow: none;
-
+.emoji-switcher {
+  display: inline-block;
+  animation: pulse 2s infinite ease-in-out;
 }
 
-
-
-.send-btn {
-
-  position: absolute;
-
-  bottom: 0;
-
-  right: 0;
-
-  padding: 8px;
-
-  background: transparent;
-
-  color: var(--primary-color);
-
-  border: none;
-
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.1); }
 }
 
-
-
-.send-btn:hover {
-
-  background: var(--bg-hover);
-
-  color: var(--primary-hover);
-
+.slogan {
+  font-size: 48px;
+  font-weight: 900;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  letter-spacing: -1px;
 }
 
+.bouncing-char {
+  display: inline-block;
+  animation: bounce 2s infinite ease-in-out;
+}
 
+@keyframes bounce {
+  0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-15px); }
+  60% { transform: translateY(-7px); }
+}
 
-.send-btn:disabled {
-
+.app-description {
+  font-size: 20px;
   color: var(--text-secondary);
-
+  max-width: 700px;
+  line-height: 1.6;
+  margin: 0;
 }
 
-
-
-.model-select {
-
-  border: none;
-
-  background: transparent;
-
-  font-weight: 600;
-
-  color: var(--text-primary);
-
-  padding-left: 0;
-
+.header-actions {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
 }
 
+.btn-lg {
+  padding: 12px 32px;
+  font-size: 16px;
+  border-radius: var(--radius-md);
+}
+
+.section-divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.section-divider::before,
+.section-divider::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.divider-text {
+  padding: 0 20px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 2px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 32px;
+}
+
+.home-footer {
+  margin-top: 32px;
+  text-align: center;
+  border-top: 1px solid var(--border-color);
+  padding-top: 32px;
+}
+
+@media (max-width: 850px) {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+  .slogan {
+    font-size: 36px;
+  }
+}
 </style>

--- a/src/views/ModelsView.vue
+++ b/src/views/ModelsView.vue
@@ -1,20 +1,38 @@
 <template>
   <div class="models-view">
     <div class="header-section mb-4">
-      <h1>Models</h1>
+      <h1>{{ t.title }}</h1>
       <p class="text-muted">
-        Manage your local LLMs and monitor system resources.
+        {{ t.subtitle }}
       </p>
     </div>
     
     <ModelManager />
-    <TokenChart />
   </div>
 </template>
 
 <script setup>
+/**
+ * Models view dedicated to managing the local Ollama model library.
+ */
+import { computed } from 'vue'
+import { useSettingsStore } from '../store/settings'
 import ModelManager from '../components/ModelManager.vue'
-import TokenChart from '../components/TokenChart.vue'
+
+const settings = useSettingsStore()
+
+const translations = {
+  en: {
+    title: 'Models',
+    subtitle: 'Manage your local LLMs and monitor system resources.'
+  },
+  zh: {
+    title: '模型',
+    subtitle: '管理您的本地大语言模型并监控系统资源。'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
 </script>
 
 <style scoped>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,16 +1,391 @@
 <template>
   <div class="settings-view">
-    <h1>Settings</h1>
-    <p>Application settings will be here.</p>
+    <div class="header-section mb-4">
+      <h1>{{ t.title }}</h1>
+      <p class="text-muted">
+        {{ t.subtitle }}
+      </p>
+    </div>
+
+    <!-- General Settings -->
+    <div class="panel mb-4">
+      <div class="panel-header">
+        <span class="font-semibold">{{ t.general }}</span>
+      </div>
+      <div class="panel-body space-y-6">
+        <!-- Theme Mode -->
+        <div class="flex items-center justify-between">
+          <div>
+            <div class="font-medium text-primary-text">
+              {{ t.themeMode }}
+            </div>
+            <div class="text-sm text-muted">
+              {{ t.themeDesc }}
+            </div>
+          </div>
+          <select 
+            v-model="settings.theme" 
+            class="w-40"
+            @change="handleThemeChange"
+          >
+            <option value="light">
+              Light
+            </option>
+            <option value="dark">
+              Dark
+            </option>
+            <option value="system">
+              System
+            </option>
+          </select>
+        </div>
+
+        <!-- Language -->
+        <div class="flex items-center justify-between">
+          <div>
+            <div class="font-medium text-primary-text">
+              {{ t.language }}
+            </div>
+            <div class="text-sm text-muted">
+              {{ t.languageDesc }}
+            </div>
+          </div>
+          <select 
+            v-model="settings.language"
+            class="w-40"
+          >
+            <option value="zh">
+              简体中文
+            </option>
+            <option value="en">
+              English
+            </option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <!-- AI Connection -->
+    <div class="panel mb-4">
+      <div class="panel-header">
+        <span class="font-semibold">{{ t.aiConnection }}</span>
+      </div>
+      <div class="panel-body space-y-4">
+        <div>
+          <label class="block text-sm font-medium mb-1 text-primary-text">{{ t.ollamaEndpoint }}</label>
+          <div class="flex gap-2">
+            <input 
+              v-model="tempEndpoint"
+              type="text" 
+              placeholder="http://127.0.0.1:11434"
+              class="flex-1 transition-colors"
+              :class="{ 'border-red-500 focus:border-red-500 focus:ring-red-500': !isValidUrl }"
+            >
+            <button 
+              class="btn btn-outline min-w-[160px] gap-2"
+              :disabled="isChecking || !isValidUrl"
+              @click="handleCheckConnection"
+            >
+              <span
+                v-if="isChecking"
+                class="loading-spinner"
+              />
+              <span
+                v-else-if="connectionStatus === 'success'"
+                class="text-success"
+              >{{ t.connected }}</span>
+              <span
+                v-else-if="connectionStatus === 'error'"
+                class="text-danger"
+              >{{ t.failed }}</span>
+              <span v-else>{{ t.checkConnection }}</span>
+            </button>
+          </div>
+          <p
+            v-if="!isValidUrl"
+            class="text-xs text-danger mt-1"
+          >
+            {{ t.validUrlError }}
+          </p>
+          <p class="text-xs text-muted mt-1">
+            {{ t.default }}: http://127.0.0.1:11434
+          </p>
+        </div>
+        
+        <div class="flex justify-end">
+          <button 
+            class="btn btn-primary" 
+            :disabled="tempEndpoint === settings.ollamaEndpoint || !isValidUrl"
+            @click="saveEndpoint"
+          >
+            {{ t.saveEndpoint }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Application Data -->
+    <div class="panel mb-4">
+      <div class="panel-header">
+        <span class="font-semibold">{{ t.appData }}</span>
+      </div>
+      <div class="panel-body">
+        <div class="flex items-center justify-between">
+          <div>
+            <div class="font-medium text-primary-text">
+              {{ t.resetData }}
+            </div>
+            <div class="text-sm text-muted">
+              {{ t.resetDesc }}
+            </div>
+          </div>
+          <button
+            class="btn btn-danger"
+            @click="handleResetData"
+          >
+            {{ t.clearDataBtn }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- About -->
+    <div class="panel">
+      <div class="panel-header">
+        <span class="font-semibold">{{ t.about }}</span>
+      </div>
+      <div class="panel-body p-6">
+        <div class="flex flex-col items-center">
+          <img
+            src="/tauri.svg"
+            alt="App Logo"
+            class="w-16 h-16 mb-4"
+          >
+          <h2 class="text-xl font-bold text-primary-text mb-1">
+            AI Toolbox
+          </h2>
+          <p class="text-muted mb-6">
+            {{ t.version }} {{ version }}
+          </p>
+          <a 
+            href="https://github.com/Aurora0201/ai-toolbox" 
+            target="_blank"
+            class="inline-flex items-center gap-2 text-primary hover:underline transition-colors"
+          >
+            <svg
+              class="w-5 h-5"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            ><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg>
+            {{ t.github }}
+          </a>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-// Settings view logic
+import { ref, computed, watch } from 'vue'
+import { useSettingsStore } from '../store/settings'
+import { useToast } from '../composables/useToast'
+import { useConfirm } from '../composables/useConfirm'
+import { invoke } from '@tauri-apps/api/core'
+import packageJson from '../../package.json'
+
+const settings = useSettingsStore()
+const { addToast } = useToast()
+const { confirm } = useConfirm()
+
+const version = packageJson.version
+const tempEndpoint = ref(settings.ollamaEndpoint)
+const isChecking = ref(false)
+const connectionStatus = ref('idle') // 'idle', 'success', 'error'
+
+const translations = {
+  en: {
+    title: 'Settings',
+    subtitle: 'Manage application preferences and AI connections.',
+    general: 'General Settings',
+    themeMode: 'Theme Mode',
+    themeDesc: 'Switch between light and dark themes.',
+    language: 'Language',
+    languageDesc: 'Select your preferred interface language.',
+    aiConnection: 'AI Connection',
+    ollamaEndpoint: 'Ollama Endpoint',
+    checkConnection: 'Check Connection',
+    connected: '✅ Connected',
+    failed: '❌ Failed',
+    validUrlError: 'Please enter a valid URL.',
+    default: 'Default',
+    saveEndpoint: 'Save Endpoint',
+    appData: 'Application Data',
+    resetData: 'Reset All Data',
+    resetDesc: 'Clear all token statistics and cached settings. This cannot be undone.',
+    clearDataBtn: 'Clear All Data',
+    about: 'About',
+    version: 'Version',
+    github: 'GitHub Repository',
+    confirmTitle: 'Reset All Data',
+    confirmMessage: 'Are you sure you want to clear all data? This will reset your token usage statistics and settings to default.',
+    confirmBtn: 'Clear Everything',
+    cancelBtn: 'Cancel',
+    toastConnected: 'Successfully connected to Ollama',
+    toastSaved: 'Ollama endpoint saved',
+    toastCleared: 'All data has been cleared. App will reload.'
+  },
+  zh: {
+    title: '设置',
+    subtitle: '管理应用首选项和 AI 连接。',
+    general: '通用设置',
+    themeMode: '主题模式',
+    themeDesc: '在浅色和深色主题之间切换。',
+    language: '语言',
+    languageDesc: '选择您偏好的界面语言。',
+    aiConnection: 'AI 连接',
+    ollamaEndpoint: 'Ollama 服务地址',
+    checkConnection: '检查连接',
+    connected: '✅ 已连接',
+    failed: '❌ 连接失败',
+    validUrlError: '请输入有效的 URL。',
+    default: '默认',
+    saveEndpoint: '保存地址',
+    appData: '应用数据',
+    resetData: '重置所有数据',
+    resetDesc: '清除所有 Token 统计和缓存设置。此操作无法撤销。',
+    clearDataBtn: '清除所有数据',
+    about: '关于',
+    version: '版本',
+    github: 'GitHub 仓库',
+    confirmTitle: '重置所有数据',
+    confirmMessage: '您确定要清除所有数据吗？这将重置您的 Token 使用统计和设置到默认状态。',
+    confirmBtn: '清除所有内容',
+    cancelBtn: '取消',
+    toastConnected: '成功连接到 Ollama',
+    toastSaved: 'Ollama 地址已保存',
+    toastCleared: '所有数据已清除。应用将重新加载。'
+  }
+}
+
+const t = computed(() => translations[settings.language] || translations.en)
+
+const isValidUrl = computed(() => {
+  try {
+    const url = new URL(tempEndpoint.value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+})
+
+watch(() => tempEndpoint.value, () => {
+  connectionStatus.value = 'idle'
+})
+
+/**
+ * Handles theme changes from the dropdown and updates the store.
+ * @param {Event} event - The change event from the select element.
+ */
+const handleThemeChange = (event) => {
+  settings.setTheme(event.target.value)
+}
+
+/**
+ * Tests the connection to the Ollama endpoint using the current temporary value.
+ * Temporarily updates the backend config to perform the check.
+ */
+const handleCheckConnection = async () => {
+  if (!isValidUrl.value) return
+  
+  isChecking.value = true
+  connectionStatus.value = 'idle'
+  
+  try {
+    // Temporarily update backend config to check this URL
+    await invoke('update_ollama_config', { endpoint: tempEndpoint.value })
+    await invoke('check_connection')
+    connectionStatus.value = 'success'
+    addToast({ message: t.value.toastConnected, type: 'success' })
+  } catch (error) {
+    connectionStatus.value = 'error'
+    addToast({ message: `Connection failed: ${error}`, type: 'error' })
+  } finally {
+    isChecking.value = false
+    // Restore saved endpoint in backend if it wasn't saved to maintain state consistency
+    if (tempEndpoint.value !== settings.ollamaEndpoint) {
+        await invoke('update_ollama_config', { endpoint: settings.ollamaEndpoint })
+    }
+  }
+}
+
+/**
+ * Permanently saves the current temporary Ollama endpoint to the store and backend.
+ */
+const saveEndpoint = async () => {
+  if (!isValidUrl.value) return
+  await settings.setOllamaEndpoint(tempEndpoint.value)
+  addToast({ message: t.value.toastSaved, type: 'success' })
+}
+
+/**
+ * Triggers a confirmation dialog to reset all application data.
+ * If confirmed, clears the database and local storage.
+ */
+const handleResetData = async () => {
+  const ok = await confirm({
+    title: t.value.confirmTitle,
+    message: t.value.confirmMessage,
+    confirmText: t.value.confirmBtn,
+    cancelText: t.value.cancelBtn
+  })
+  
+  if (ok) {
+    try {
+      await invoke('clear_all_data')
+      // Clear localStorage
+      localStorage.removeItem('ai-toolbox-settings')
+      addToast({ message: t.value.toastCleared, type: 'info' })
+      setTimeout(() => {
+        window.location.reload()
+      }, 1500)
+    } catch (error) {
+      addToast({ message: `Failed to clear data: ${error}`, type: 'error' })
+    }
+  }
+}
 </script>
 
 <style scoped>
 .settings-view {
-  padding: 20px;
+  padding: 32px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.mb-4 { margin-bottom: 24px; }
+.p-6 { padding: 32px; }
+
+.space-y-6 > * + * {
+  margin-top: 24px;
+}
+
+.space-y-4 > * + * {
+  margin-top: 16px;
+}
+
+.text-danger { color: var(--danger-color); }
+.text-success { color: var(--success-color); }
+
+.loading-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0,0,0,0.1);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 </style>


### PR DESCRIPTION
## Summary
Close #7 

引入了完整的设置页面，实现了应用个性化配置的持久化存储。
用户现在可以切换语言（中/英）、主题模式（深/浅/跟随系统），并自定义 Ollama 后端连接地址。

## ✨ Key Features (新特性)

- **Internationalization (i18n)**:
    - 集成 `vue-i18n`。
    - 实现了 English / 简体中文 的实时切换。
- **Appearance (外观)**:
    - 支持 Light / Dark / System 三种主题模式。
    - 适配了 TailwindCSS 的 Dark Mode 类名策略。
- **Connection (连接)**:
    - 支持自定义 Ollama API Endpoint (默认为 localhost:11434)。
    - 配置修改后自动持久化到 `localStorage` (通过 Pinia)。
- **Data Management (数据)**:
    - 提供了清除本地数据库/重置缓存的入口。

## 🛠️ Technical Details (技术细节)

- **State Management**: 使用 `Pinia` + `pinia-plugin-persistedstate` 实现配置项的自动保存与恢复。
- **Store Structure**: 新增 `useSettingsStore`，负责管理 `theme`, `locale`, `ollamaEndpoint` 等状态。
- **Components**: 新增 `SettingsView.vue` 及相关的表单组件（Select, Input with Validation）。

## 📸 Screenshots (UI 验收)
<img width="986" height="793" alt="image" src="https://github.com/user-attachments/assets/ba4b3d20-bba9-4f78-b457-355d5a4e2aea" />

<img width="986" height="793" alt="image" src="https://github.com/user-attachments/assets/06903b24-df00-4692-a673-520c63882e57" />

<img width="986" height="793" alt="image" src="https://github.com/user-attachments/assets/2630de6f-d686-42a3-a88b-f59144fb7712" />

<img width="986" height="793" alt="image" src="https://github.com/user-attachments/assets/9ad0fa2f-0efa-4975-aae3-a10a60eea2e8" />


## ✅ Checklist (自测清单)

- [x] **Persistence**: 重启应用后，修改过的语言和主题依然保持生效。
- [x] **Ollama Config**: 修改 API 地址后，Home 页面的连接检查能正确反馈结果。
- [x] **Responsiveness**: 页面在不同窗口大小下布局正常。
- [x] `npm run lint` 检查通过。